### PR TITLE
Feature/231 filtrer rader i prosjektstatus pa ledige

### DIFF
--- a/src/components/DDItem.tsx
+++ b/src/components/DDItem.tsx
@@ -3,6 +3,7 @@ import { useFetchedData } from '../hooks/service';
 import { GridItem, GridItemHeader, GridItemContent } from './GridItem';
 import { Skeleton } from '@material-ui/lab';
 import DataTable from '../components/dd/DataTable';
+import DataTableWithFilter from '../components/dd/DataTableWithFilter'
 import SearchInput from '../components/SearchInput';
 import DropdownPicker from '../components/DropdownPicker';
 
@@ -133,4 +134,35 @@ export function DDTable({ payload, title, props }: DDComponentProps) {
       </GridItemContent>
     </>
   );
+}
+
+export function DDTableWithFilter({ payload, title, props }: DDComponentProps) {
+  if (props && props['filterFunction'] && props['checkBoxColumnTitle'] && props['checkBoxLabel'])
+    return (
+      <>
+        <GridItemHeader title={title}>
+          <SearchInput />
+        </GridItemHeader>
+
+        <GridItemContent>
+          <DataTableWithFilter
+            rows={payload as { rowData: any[] }[]}
+            columns={[]}
+            filterFunction={props['filterFunction']}
+            checkBoxColumnTitle={props['checkBoxColumnTitle']}
+            checkBoxLabel={props['checkBoxLabel']}
+            {...props}
+          />
+        </GridItemContent>
+      </>
+    );
+  else {
+    return (
+      <DDTable 
+        payload={payload as DDPayload}
+        title={title}
+        props={props}
+      />
+    )
+  }
 }

--- a/src/components/DDItem.tsx
+++ b/src/components/DDItem.tsx
@@ -3,7 +3,7 @@ import { useFetchedData } from '../hooks/service';
 import { GridItem, GridItemHeader, GridItemContent } from './GridItem';
 import { Skeleton } from '@material-ui/lab';
 import DataTable from '../components/dd/DataTable';
-import DataTableWithFilter from '../components/dd/DataTableWithFilter'
+import DataTableWithFilter from '../components/dd/DataTableWithFilter';
 import SearchInput from '../components/SearchInput';
 import DropdownPicker from '../components/DropdownPicker';
 
@@ -137,7 +137,12 @@ export function DDTable({ payload, title, props }: DDComponentProps) {
 }
 
 export function DDTableWithFilter({ payload, title, props }: DDComponentProps) {
-  if (props && props['filterFunction'] && props['checkBoxColumnTitle'] && props['checkBoxLabel'])
+  if (
+    props &&
+    props['filterFunction'] &&
+    props['checkBoxColumnTitle'] &&
+    props['checkBoxLabel']
+  )
     return (
       <>
         <GridItemHeader title={title}>
@@ -158,11 +163,7 @@ export function DDTableWithFilter({ payload, title, props }: DDComponentProps) {
     );
   else {
     return (
-      <DDTable 
-        payload={payload as DDPayload}
-        title={title}
-        props={props}
-      />
-    )
+      <DDTable payload={payload as DDPayload} title={title} props={props} />
+    );
   }
 }

--- a/src/components/DataTableCells.tsx
+++ b/src/components/DataTableCells.tsx
@@ -96,7 +96,9 @@ const BlackCheckBox = withStyles({
     },
   },
   checked: {},
-})((props: CheckboxProps) => <Checkbox color="default" disableRipple {...props} />);
+})((props: CheckboxProps) => (
+  <Checkbox color="default" disableRipple {...props} />
+));
 
 const useCheckBoxStyles = makeStyles({
   label: {
@@ -115,14 +117,19 @@ interface ConsultantHeaderCellProps {
   changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-export function HeaderCellWithCheckBox({ columnTitle, label, changeHandler }: ConsultantHeaderCellProps) {
+export function HeaderCellWithCheckBox({
+  columnTitle,
+  label,
+  changeHandler,
+}: ConsultantHeaderCellProps) {
   const classes = useCheckBoxStyles();
 
   return (
     <div className={classes.position}>
-      {columnTitle} 
-      <FormControlLabel className={classes.label}
-        control={<BlackCheckBox onChange={changeHandler}/>}
+      {columnTitle}
+      <FormControlLabel
+        className={classes.label}
+        control={<BlackCheckBox onChange={changeHandler} />}
         label={label}
       />
     </div>

--- a/src/components/DataTableCells.tsx
+++ b/src/components/DataTableCells.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Avatar } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import { Avatar, FormControlLabel } from '@material-ui/core';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import { ReactComponent as FallbackUserIcon } from '../assets/fallback_user.svg';
 
 const useConsultantCellStyles = makeStyles({
@@ -80,6 +81,50 @@ export function CustomerStatusCell({
     <div className={classes.root}>
       <div>{value || '-'}</div>
       <div className={classes.statusLabel} />
+    </div>
+  );
+}
+
+const BlackCheckBox = withStyles({
+  root: {
+    color: '#333333',
+    '&$checked': {
+      color: '#333333',
+    },
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+  },
+  checked: {},
+})((props: CheckboxProps) => <Checkbox color="default" disableRipple {...props} />);
+
+const useCheckBoxStyles = makeStyles({
+  label: {
+    marginRight: 0,
+  },
+  position: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});
+
+interface ConsultantHeaderCellProps {
+  columnTitle: string,
+  label: string
+  changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void
+}
+
+export function HeaderCellWithCheckBox({ columnTitle, label, changeHandler }: ConsultantHeaderCellProps) {
+  const classes = useCheckBoxStyles();
+
+  return (
+    <div className={classes.position}>
+      {columnTitle} 
+      <FormControlLabel className={classes.label}
+        control={<BlackCheckBox onChange={changeHandler}/>}
+        label={label}
+      />
     </div>
   );
 }

--- a/src/components/DataTableCells.tsx
+++ b/src/components/DataTableCells.tsx
@@ -110,9 +110,9 @@ const useCheckBoxStyles = makeStyles({
 });
 
 interface ConsultantHeaderCellProps {
-  columnTitle: string,
-  label: string
-  changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void
+  columnTitle: string;
+  label: string;
+  changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 export function HeaderCellWithCheckBox({ columnTitle, label, changeHandler }: ConsultantHeaderCellProps) {

--- a/src/components/dd/DataTable.tsx
+++ b/src/components/dd/DataTable.tsx
@@ -12,9 +12,8 @@ import {
 } from '@material-ui/core';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
-import { HeaderCellWithCheckBox } from '../DataTableCells';
 
-interface DataTableColumn {
+export interface DataTableColumn {
   title: string;
   expandable?: boolean;
   renderCell?: (props: { data: any; rowData: any[] }) => JSX.Element;
@@ -24,7 +23,7 @@ interface DataTableCell extends DataTableColumn {
   data: any;
 }
 
-interface DataTableRow {
+export interface DataTableRow {
   rowData: any[];
   columns: DataTableColumn[];
 }
@@ -37,7 +36,7 @@ interface DataTableProps {
 type DataTableRowProps = DataTableRow;
 type DataTableCellProps = DataTableCell;
 
-const useRowStyles = makeStyles({
+export const useRowStyles = makeStyles({
   root: {
     '& > *': {
       borderBottom: 'unset',
@@ -69,7 +68,7 @@ const useRowStyles = makeStyles({
   },
 });
 
-function Row({ rowData, columns }: DataTableRowProps) {
+export function Row({ rowData, columns }: DataTableRowProps) {
   const [open, setOpen] = useState(false);
   const classes = useRowStyles();
 
@@ -114,7 +113,7 @@ function Row({ rowData, columns }: DataTableRowProps) {
   );
 }
 
-const useTableStyles = makeStyles({
+export const useTableStyles = makeStyles({
   root: {},
   tableHead: {
     fontWeight: 'bold',
@@ -133,41 +132,20 @@ export default function DataTable({ columns, rows }: DataTableProps) {
   const tableClasses = useTableStyles();
   const rowClasses = useRowStyles();
 
-  const [filterFreeResources, setFilterFreeResources] = useState(false);
-
-  const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setFilterFreeResources(event.target.checked);
-  };
-
-  let showRows = rows
-  if (filterFreeResources){
-    showRows = showRows.filter(row => row.rowData[3].status === 'green') // TODO: Update filter to reflect structure of actual data from backend
-  }
-
   return (
     <TableContainer className={tableClasses.root}>
       <Table>
         <TableHead className={tableClasses.tableHead}>
           <TableRow className={rowClasses.row}>
-            {columns.map((x) => {
-            if (x.title==="Konsulent"){
-              return (
-                <TableCell className={rowClasses.cell} key={x.title}>
-                  <HeaderCellWithCheckBox columnTitle={x.title} label={"Vis kun ledige"} changeHandler={handleCheckBoxChange}/>
-                </TableCell>
-              )
-            }
-            else{ 
-              return (
+            {columns.map((x) => (
               <TableCell className={rowClasses.cell} key={x.title}>
                 {x.title}
               </TableCell>
-              )
-            }})}
+            ))}
           </TableRow>
         </TableHead>
         <TableBody className={tableClasses.tableBody}>
-          {showRows.map((row, i) => (
+          {rows.map((row, i) => (
             <Row key={i} {...row} columns={columns} />
           ))}
         </TableBody>

--- a/src/components/dd/DataTable.tsx
+++ b/src/components/dd/DataTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import {
   Box,
   Collapse,
@@ -9,7 +9,9 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  FormControlLabel,
 } from '@material-ui/core';
+import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 
@@ -113,6 +115,48 @@ function Row({ rowData, columns }: DataTableRowProps) {
   );
 }
 
+const BlackCheckBox = withStyles({
+  root: {
+    color: '#333333',
+    '&$checked': {
+      color: '#333333',
+    },
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+  },
+  checked: {},
+})((props: CheckboxProps) => <Checkbox color="default" {...props} />);
+
+const useCheckBoxStyles = makeStyles({
+  label: {
+    marginRight: 0,
+  },
+  position: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});
+
+interface ConsultantHeaderCellProps {
+  column: DataTableColumn
+}
+
+function ConsultantHeaderCell({ column }: ConsultantHeaderCellProps) {
+  const classes = useCheckBoxStyles();
+
+  return (
+    <div className={classes.position}>
+      {column.title} 
+      <FormControlLabel className={classes.label}
+        control={<BlackCheckBox/>}
+        label="Vis kun ledige"
+      />
+    </div>
+  );
+}
+
 const useTableStyles = makeStyles({
   root: {},
   tableHead: {
@@ -137,11 +181,21 @@ export default function DataTable({ columns, rows }: DataTableProps) {
       <Table>
         <TableHead className={tableClasses.tableHead}>
           <TableRow className={rowClasses.row}>
-            {columns.map((x) => (
+            {columns.map((x) => {
+            if (x.title==="Konsulent"){
+              return (
+                <TableCell className={rowClasses.cell} key={x.title}>
+                  <ConsultantHeaderCell column={x}/>
+                </TableCell>
+              )
+            }
+            else{ 
+              return (
               <TableCell className={rowClasses.cell} key={x.title}>
                 {x.title}
               </TableCell>
-            ))}
+              )
+            }})}
           </TableRow>
         </TableHead>
         <TableBody className={tableClasses.tableBody}>

--- a/src/components/dd/DataTable.tsx
+++ b/src/components/dd/DataTable.tsx
@@ -140,18 +140,20 @@ const useCheckBoxStyles = makeStyles({
 });
 
 interface ConsultantHeaderCellProps {
-  column: DataTableColumn
+  column: DataTableColumn,
+  label: string
+  changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
 
-function ConsultantHeaderCell({ column }: ConsultantHeaderCellProps) {
+function HeaderCellWithCheckBox({ column, label, changeHandler }: ConsultantHeaderCellProps) {
   const classes = useCheckBoxStyles();
 
   return (
     <div className={classes.position}>
       {column.title} 
       <FormControlLabel className={classes.label}
-        control={<BlackCheckBox/>}
-        label="Vis kun ledige"
+        control={<BlackCheckBox onChange={changeHandler}/>}
+        label={label}
       />
     </div>
   );
@@ -176,6 +178,17 @@ export default function DataTable({ columns, rows }: DataTableProps) {
   const tableClasses = useTableStyles();
   const rowClasses = useRowStyles();
 
+  const [filterFreeResources, setFilterFreeResources] = useState(false);
+
+  const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterFreeResources(event.target.checked);
+  };
+
+  let showRows = rows
+  if (filterFreeResources){
+    showRows = showRows.filter(row => row.rowData[3].status === 'green') // TODO: Update filter to reflect structure of actual data from backend
+  }
+
   return (
     <TableContainer className={tableClasses.root}>
       <Table>
@@ -185,7 +198,7 @@ export default function DataTable({ columns, rows }: DataTableProps) {
             if (x.title==="Konsulent"){
               return (
                 <TableCell className={rowClasses.cell} key={x.title}>
-                  <ConsultantHeaderCell column={x}/>
+                  <HeaderCellWithCheckBox column={x} label={"Vis kun ledige"} changeHandler={handleCheckBoxChange}/>
                 </TableCell>
               )
             }
@@ -199,7 +212,7 @@ export default function DataTable({ columns, rows }: DataTableProps) {
           </TableRow>
         </TableHead>
         <TableBody className={tableClasses.tableBody}>
-          {rows.map((row, i) => (
+          {showRows.map((row, i) => (
             <Row key={i} {...row} columns={columns} />
           ))}
         </TableBody>

--- a/src/components/dd/DataTable.tsx
+++ b/src/components/dd/DataTable.tsx
@@ -126,7 +126,7 @@ const BlackCheckBox = withStyles({
     },
   },
   checked: {},
-})((props: CheckboxProps) => <Checkbox color="default" {...props} />);
+})((props: CheckboxProps) => <Checkbox color="default" disableRipple {...props} />);
 
 const useCheckBoxStyles = makeStyles({
   label: {

--- a/src/components/dd/DataTable.tsx
+++ b/src/components/dd/DataTable.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { makeStyles, withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import {
   Box,
   Collapse,
@@ -9,11 +9,10 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  FormControlLabel,
 } from '@material-ui/core';
-import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
+import { HeaderCellWithCheckBox } from '../DataTableCells';
 
 interface DataTableColumn {
   title: string;
@@ -115,50 +114,6 @@ function Row({ rowData, columns }: DataTableRowProps) {
   );
 }
 
-const BlackCheckBox = withStyles({
-  root: {
-    color: '#333333',
-    '&$checked': {
-      color: '#333333',
-    },
-    '&:hover': {
-      backgroundColor: 'transparent',
-    },
-  },
-  checked: {},
-})((props: CheckboxProps) => <Checkbox color="default" disableRipple {...props} />);
-
-const useCheckBoxStyles = makeStyles({
-  label: {
-    marginRight: 0,
-  },
-  position: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-});
-
-interface ConsultantHeaderCellProps {
-  column: DataTableColumn,
-  label: string
-  changeHandler: (event: React.ChangeEvent<HTMLInputElement>) => void
-}
-
-function HeaderCellWithCheckBox({ column, label, changeHandler }: ConsultantHeaderCellProps) {
-  const classes = useCheckBoxStyles();
-
-  return (
-    <div className={classes.position}>
-      {column.title} 
-      <FormControlLabel className={classes.label}
-        control={<BlackCheckBox onChange={changeHandler}/>}
-        label={label}
-      />
-    </div>
-  );
-}
-
 const useTableStyles = makeStyles({
   root: {},
   tableHead: {
@@ -198,7 +153,7 @@ export default function DataTable({ columns, rows }: DataTableProps) {
             if (x.title==="Konsulent"){
               return (
                 <TableCell className={rowClasses.cell} key={x.title}>
-                  <HeaderCellWithCheckBox column={x} label={"Vis kun ledige"} changeHandler={handleCheckBoxChange}/>
+                  <HeaderCellWithCheckBox columnTitle={x.title} label={"Vis kun ledige"} changeHandler={handleCheckBoxChange}/>
                 </TableCell>
               )
             }

--- a/src/components/dd/DataTableWithFilter.tsx
+++ b/src/components/dd/DataTableWithFilter.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+} from '@material-ui/core';
+import { HeaderCellWithCheckBox } from '../DataTableCells';
+import { DataTableRow, DataTableColumn, useTableStyles, useRowStyles, Row } from '../dd/DataTable';
+
+interface DataTableWithFilterProps {
+    columns: DataTableColumn[];
+    rows: Omit<DataTableRow, 'columns'>[];
+    filterFunction: (rows: Pick<DataTableRow, "rowData">) => Pick<DataTableRow, "rowData">;
+    checkBoxColumnTitle: string;
+    checkBoxLabel: string;
+  }
+
+export default function DataTableWithFilter({ columns, rows, filterFunction, checkBoxColumnTitle, checkBoxLabel}: DataTableWithFilterProps) {
+    const tableClasses = useTableStyles();
+    const rowClasses = useRowStyles();
+
+    const [filterFreeResources, setFilterFreeResources] = useState(false);
+
+    const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        setFilterFreeResources(event.target.checked);
+    };
+
+    let showRows = rows
+    if (filterFreeResources){
+        showRows = showRows.filter(row => filterFunction(row)) 
+    }
+
+    return (
+        <TableContainer className={tableClasses.root}>
+        <Table>
+            <TableHead className={tableClasses.tableHead}>
+            <TableRow className={rowClasses.row}>
+                {columns.map((x) => {
+                if (x.title===checkBoxColumnTitle){
+                return (
+                    <TableCell className={rowClasses.cell} key={x.title}>
+                    <HeaderCellWithCheckBox columnTitle={x.title} label={checkBoxLabel} changeHandler={handleCheckBoxChange}/>
+                    </TableCell>
+                )
+                }
+                else{ 
+                return (
+                <TableCell className={rowClasses.cell} key={x.title}>
+                    {x.title}
+                </TableCell>
+                )
+                }})}
+            </TableRow>
+            </TableHead>
+            <TableBody className={tableClasses.tableBody}>
+            {showRows.map((row, i) => (
+                <Row key={i} {...row} columns={columns} />
+            ))}
+            </TableBody>
+        </Table>
+        </TableContainer>
+    );
+}

--- a/src/components/dd/DataTableWithFilter.tsx
+++ b/src/components/dd/DataTableWithFilter.tsx
@@ -8,59 +8,77 @@ import {
   TableRow,
 } from '@material-ui/core';
 import { HeaderCellWithCheckBox } from '../DataTableCells';
-import { DataTableRow, DataTableColumn, useTableStyles, useRowStyles, Row } from '../dd/DataTable';
+import {
+  DataTableRow,
+  DataTableColumn,
+  useTableStyles,
+  useRowStyles,
+  Row,
+} from '../dd/DataTable';
 
 interface DataTableWithFilterProps {
-    columns: DataTableColumn[];
-    rows: Omit<DataTableRow, 'columns'>[];
-    filterFunction: (rows: Pick<DataTableRow, "rowData">) => Pick<DataTableRow, "rowData">;
-    checkBoxColumnTitle: string;
-    checkBoxLabel: string;
+  columns: DataTableColumn[];
+  rows: Omit<DataTableRow, 'columns'>[];
+  filterFunction: (
+    rows: Pick<DataTableRow, 'rowData'>
+  ) => Pick<DataTableRow, 'rowData'>;
+  checkBoxColumnTitle: string;
+  checkBoxLabel: string;
+}
+
+export default function DataTableWithFilter({
+  columns,
+  rows,
+  filterFunction,
+  checkBoxColumnTitle,
+  checkBoxLabel,
+}: DataTableWithFilterProps) {
+  const tableClasses = useTableStyles();
+  const rowClasses = useRowStyles();
+
+  const [filterFreeResources, setFilterFreeResources] = useState(false);
+
+  const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setFilterFreeResources(event.target.checked);
+  };
+
+  let showRows = rows;
+  if (filterFreeResources) {
+    showRows = showRows.filter((row) => filterFunction(row));
   }
 
-export default function DataTableWithFilter({ columns, rows, filterFunction, checkBoxColumnTitle, checkBoxLabel}: DataTableWithFilterProps) {
-    const tableClasses = useTableStyles();
-    const rowClasses = useRowStyles();
-
-    const [filterFreeResources, setFilterFreeResources] = useState(false);
-
-    const handleCheckBoxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        setFilterFreeResources(event.target.checked);
-    };
-
-    let showRows = rows
-    if (filterFreeResources){
-        showRows = showRows.filter(row => filterFunction(row)) 
-    }
-
-    return (
-        <TableContainer className={tableClasses.root}>
-        <Table>
-            <TableHead className={tableClasses.tableHead}>
-            <TableRow className={rowClasses.row}>
-                {columns.map((x) => {
-                if (x.title===checkBoxColumnTitle){
+  return (
+    <TableContainer className={tableClasses.root}>
+      <Table>
+        <TableHead className={tableClasses.tableHead}>
+          <TableRow className={rowClasses.row}>
+            {columns.map((x) => {
+              if (x.title === checkBoxColumnTitle) {
                 return (
-                    <TableCell className={rowClasses.cell} key={x.title}>
-                    <HeaderCellWithCheckBox columnTitle={x.title} label={checkBoxLabel} changeHandler={handleCheckBoxChange}/>
-                    </TableCell>
-                )
-                }
-                else{ 
+                  <TableCell className={rowClasses.cell} key={x.title}>
+                    <HeaderCellWithCheckBox
+                      columnTitle={x.title}
+                      label={checkBoxLabel}
+                      changeHandler={handleCheckBoxChange}
+                    />
+                  </TableCell>
+                );
+              } else {
                 return (
-                <TableCell className={rowClasses.cell} key={x.title}>
+                  <TableCell className={rowClasses.cell} key={x.title}>
                     {x.title}
-                </TableCell>
-                )
-                }})}
-            </TableRow>
-            </TableHead>
-            <TableBody className={tableClasses.tableBody}>
-            {showRows.map((row, i) => (
-                <Row key={i} {...row} columns={columns} />
-            ))}
-            </TableBody>
-        </Table>
-        </TableContainer>
-    );
+                  </TableCell>
+                );
+              }
+            })}
+          </TableRow>
+        </TableHead>
+        <TableBody className={tableClasses.tableBody}>
+          {showRows.map((row, i) => (
+            <Row key={i} {...row} columns={columns} />
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
 }

--- a/src/pages/Employee.tsx
+++ b/src/pages/Employee.tsx
@@ -5,7 +5,8 @@ import {
   ProjectStatusCell,
   CustomerStatusCell,
 } from '../components/DataTableCells';
-import DDItem, { DDTable, DDChart } from '../components/DDItem';
+import DDItem, { DDTable, DDChart, DDTableWithFilter } from '../components/DDItem';
+import { DataTableRow } from '../components/dd/DataTable';
 import { Skeleton } from '@material-ui/lab';
 
 export default function Employee() {
@@ -59,7 +60,7 @@ export default function Employee() {
         url={'/api/data/projectStatus'}
         title={'Prosjektstatus'}
         fullSize={true}
-        Component={DDTable}
+        Component={DDTableWithFilter}
         dataComponentProps={{
           columns: [
             {
@@ -71,6 +72,9 @@ export default function Employee() {
             { title: 'Prosjektstatus', renderCell: ProjectStatusCell },
             { title: 'Kunde', renderCell: CustomerStatusCell },
           ],
+          filterFunction: (row: Pick<DataTableRow, "rowData">) => row.rowData[3].status === 'green', // TODO: Update filter to reflect structure of actual data from backend
+          checkBoxColumnTitle: 'Konsulent',
+          checkBoxLabel: 'Vis kun ledige',
         }}
         SkeletonComponent={TableSkeleton}
       />

--- a/src/pages/Employee.tsx
+++ b/src/pages/Employee.tsx
@@ -72,7 +72,8 @@ export default function Employee() {
             { title: 'Prosjektstatus', renderCell: ProjectStatusCell },
             { title: 'Kunde', renderCell: CustomerStatusCell },
           ],
-          filterFunction: (row: Pick<DataTableRow, "rowData">) => row.rowData[3].status === 'green', // TODO: Update filter to reflect structure of actual data from backend
+          filterFunction: (row: Pick<DataTableRow, 'rowData'>) =>
+            row.rowData[3].status === 'green', // TODO: Update filter to reflect structure of actual backend data
           checkBoxColumnTitle: 'Konsulent',
           checkBoxLabel: 'Vis kun ledige',
         }}

--- a/src/pages/Employee.tsx
+++ b/src/pages/Employee.tsx
@@ -5,7 +5,7 @@ import {
   ProjectStatusCell,
   CustomerStatusCell,
 } from '../components/DataTableCells';
-import DDItem, { DDTable, DDChart, DDTableWithFilter } from '../components/DDItem';
+import DDItem, { DDChart, DDTableWithFilter } from '../components/DDItem';
 import { DataTableRow } from '../components/dd/DataTable';
 import { Skeleton } from '@material-ui/lab';
 


### PR DESCRIPTION
- Laget ny DDItem type: DataTableWithFilter
- Prosjektstatus tabellen bruker nå denne typen istedet for basic DataTable, og filtrerer på om en konsulent er ledig

Må fikses senere: Akkurat nå fungerer filteret på om konsluenter er ledige basert på dummy dataen, hvis actual data ikke har samme struktur, så må dette oppdateres. Laget en TODO kommentar hvor det er relevant, i Employee filen under /pages.

Ifht testing: Ikke gjort noe testing her, i avvente av ordentlig oppsett å struktur på hvordan vi ønsker dem, siden cypress ikke er lagt inn i prosjektet enda, osv. 