### PR TITLE
Feature/350 swap experience chart from pie to bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-debug.log*
 yarn-error.log*
 
 .serverless
+
+.idea

--- a/backend/repository/data.js
+++ b/backend/repository/data.js
@@ -356,7 +356,7 @@ exports.experienceDistribution = async ({ data }) => {
   const experience = data;
   const [groups, detailedGroups] = setInGroups(experience);
   return {
-    componentType: 'Pie',
+    componentType: 'Bar',
     setNames: ['Erfaring', 'Detaljert oversikt'],
     sets: {
       Erfaring: groups,

--- a/backend/repository/data.js
+++ b/backend/repository/data.js
@@ -356,7 +356,6 @@ exports.experienceDistribution = async ({ data }) => {
   const experience = data;
   const [groups, detailedGroups] = setInGroups(experience);
   return {
-    componentType: 'Bar',
     setNames: ['Erfaring', 'Detaljert oversikt'],
     sets: {
       Erfaring: groups,
@@ -373,7 +372,6 @@ exports.ageDistribution = async ({ data }) => {
   const [setAgeDist, setAgeDistGroup] = data
 
   return {
-    componentType: 'Bar',
     setNames: ['Aldersgrupper', 'Detaljert oversikt'],
     sets: {
       Aldersgrupper: setAgeDistGroup.map(({ age_group, count }) => ({
@@ -476,7 +474,6 @@ exports.fagEvents = async ({ data }) => {
   const eventSet = getEventSet(data);
 
   return {
-    componentType: 'Line',
     setNames: ['Fag og hendelser'],
     sets: {
       'Fag og hendelser': eventSet,
@@ -491,7 +488,6 @@ exports.education = async ({ data }) => {
   const education = data;
 
   return {
-    componentType: 'Pie',
     setNames: ['Utdanning'],
     sets: {
       Utdanning: education,
@@ -590,7 +586,6 @@ exports.competenceMapping = async ({ data }) => {
   };
 
   return {
-    componentType: 'Sunburst',
     setNames: ['Kompetanse', 'Motivasjon'],
     sets: {
       Kompetanse: competenceCategories(competence),
@@ -654,7 +649,6 @@ exports.competenceAmount = async ({ data }) => {
   });
 
   return {
-    componentType: 'Radar',
     setNames: ['Kompetansemengde'],
     sets: {
       Kompetansemengde: mergedArrs,
@@ -741,7 +735,6 @@ exports.employeeRadar = async ({ data, parameters: { user_id } = {} }) => {
   );
 
   return {
-    componentType: 'Radar',
     setNames: setNames,
     sets: structuredCats,
   };
@@ -795,7 +788,6 @@ exports.competenceAreas = async ({ data }) => {
   );
 
   return {
-    componentType: 'Radar',
     setNames: setNames,
     sets: structuredCats,
   };

--- a/src/components/BigChart.tsx
+++ b/src/components/BigChart.tsx
@@ -5,7 +5,6 @@ import { withStyles } from '@material-ui/core/styles';
 const DialogBox = withStyles(() => ({
   paper: {
     width: '950px',
-    height: '604px',
     borderRadius: '0px',
   },
 }))(Dialog);

--- a/src/components/ChartDisplayOptions.tsx
+++ b/src/components/ChartDisplayOptions.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+import { ChartDetails, ChartVariant } from '../data/DDChart';
+import { BarChart, PieChart, ShowChart } from '@material-ui/icons';
+import { makeStyles } from '@material-ui/core/styles';
+import { createStyles } from '@material-ui/core';
+
+// TODO: add icons for all chart variants
+const chartVariantInfo: {
+  [key in ChartVariant]: {
+    label: string;
+    icon: React.ReactNode;
+  };
+} = {
+  Line: { label: 'linjediagram', icon: <ShowChart /> },
+  Bar: { label: 'stolpediagram', icon: <BarChart /> },
+  Pie: { label: 'kakediagram', icon: <PieChart /> },
+  Radar: { label: 'radardiagram', icon: <PieChart /> },
+  Sunburst: { label: 'sunburst', icon: <PieChart /> },
+  PercentArea: { label: 'prosent', icon: <PieChart /> },
+};
+
+interface ChartVariantToggleProps {
+  chartVariants: Array<ChartDetails>;
+  selected: number;
+  onChange: (value: number) => void;
+  big?: boolean;
+}
+
+export function ChartVariantToggle({
+  chartVariants,
+  selected,
+  onChange,
+  big = false, // TODO: resize on fullscreen?
+}: ChartVariantToggleProps) {
+  const handleChartVariantChange = (
+    event: React.MouseEvent,
+    newChartIndex: number | null
+  ) => {
+    if (typeof newChartIndex === 'number') {
+      onChange(newChartIndex);
+    }
+  };
+
+  return (
+    <ToggleButtonGroup
+      exclusive
+      value={selected}
+      onChange={handleChartVariantChange}
+      size="small"
+    >
+      {chartVariants.map((chartVariant, chartIndex) => {
+        const { label, icon: ChartIcon } = chartVariantInfo[chartVariant.type];
+        const buttonLabel = `Vis som ${label}`;
+
+        return (
+          <ToggleButton
+            key={label}
+            value={chartIndex}
+            disableRipple
+            aria-label={buttonLabel}
+            title={buttonLabel}
+          >
+            {ChartIcon}
+          </ToggleButton>
+        );
+      })}
+    </ToggleButtonGroup>
+  );
+}
+
+const useStyles = makeStyles(() =>
+  createStyles({
+    chartDisplayOptions: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignContent: 'flex-start',
+      alignItems: 'flex-start',
+    },
+  })
+);
+
+interface ChartDisplayOptionsProps {
+  children: React.ReactNode | React.ReactNode[];
+}
+
+export function ChartDisplayOptions({ children }: ChartDisplayOptionsProps) {
+  const classes = useStyles();
+
+  return <div className={classes.chartDisplayOptions}>{children}</div>;
+}

--- a/src/components/ChartDisplayOptions.tsx
+++ b/src/components/ChartDisplayOptions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
-import { ChartDetails, ChartVariant } from '../data/DDChart';
+import { ChartComponentInfo, ChartVariant } from '../data/DDChart';
 import { BarChart, Error, PieChart, ShowChart } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles } from '@material-ui/core';
@@ -19,7 +19,7 @@ const chartVariantInfo: {
 };
 
 interface ChartVariantToggleProps {
-  chartVariants: Array<ChartDetails>;
+  chartVariants: Array<ChartComponentInfo>;
   selected: number;
   onChange: (value: number) => void;
   big?: boolean;
@@ -29,7 +29,7 @@ export function ChartVariantToggle({
   chartVariants,
   selected,
   onChange,
-  big = false, // TODO: resize on fullscreen?
+  big = false,
 }: ChartVariantToggleProps) {
   const handleChartVariantChange = (
     event: React.MouseEvent,
@@ -45,7 +45,7 @@ export function ChartVariantToggle({
       exclusive
       value={selected}
       onChange={handleChartVariantChange}
-      size="small"
+      size={big ? 'medium' : 'small'}
     >
       {chartVariants.map((chartVariant, chartIndex) => {
         const { label, icon: ChartIcon } = chartVariantInfo[chartVariant.type];

--- a/src/components/ChartDisplayOptions.tsx
+++ b/src/components/ChartDisplayOptions.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
 import { ChartDetails, ChartVariant } from '../data/DDChart';
-import { BarChart, PieChart, ShowChart } from '@material-ui/icons';
+import { BarChart, Error, PieChart, ShowChart } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { createStyles } from '@material-ui/core';
 
-// TODO: add icons for all chart variants
 const chartVariantInfo: {
   [key in ChartVariant]: {
     label: string;
@@ -15,9 +14,8 @@ const chartVariantInfo: {
   Line: { label: 'linjediagram', icon: <ShowChart /> },
   Bar: { label: 'stolpediagram', icon: <BarChart /> },
   Pie: { label: 'kakediagram', icon: <PieChart /> },
-  Radar: { label: 'radardiagram', icon: <PieChart /> },
-  Sunburst: { label: 'sunburst', icon: <PieChart /> },
-  PercentArea: { label: 'prosent', icon: <PieChart /> },
+  Radar: { label: 'radardiagram', icon: <Error /> },
+  Sunburst: { label: 'sunburst-diagram', icon: <Error /> },
 };
 
 interface ChartVariantToggleProps {

--- a/src/components/EmployeeInfo.tsx
+++ b/src/components/EmployeeInfo.tsx
@@ -260,7 +260,15 @@ export default function EmployeeInfo({
           SkeletonComponent={ChartSkeleton}
           fullSize
           dataComponentProps={{
-            valueKey: ['motivasjon', 'kompetanse'],
+            chartVariants: [
+              {
+                chartType: 'Radar',
+                chartProps: {
+                  groupKey: 'kategori',
+                  valueKey: ['motivasjon', 'kompetanse'],
+                },
+              },
+            ],
           }}
         />
       </div>

--- a/src/components/EmployeeInfo.tsx
+++ b/src/components/EmployeeInfo.tsx
@@ -262,8 +262,8 @@ export default function EmployeeInfo({
           dataComponentProps={{
             chartVariants: [
               {
-                chartType: 'Radar',
-                chartProps: {
+                type: 'Radar',
+                props: {
                   groupKey: 'kategori',
                   valueKey: ['motivasjon', 'kompetanse'],
                 },

--- a/src/components/GridItem.tsx
+++ b/src/components/GridItem.tsx
@@ -33,7 +33,7 @@ const useStyles = makeStyles(() =>
     },
     gridContentRoot: {
       width: '100%',
-      padding: '20px 15px 15px 15px',
+      padding: '15px',
       backgroundColor: 'white',
       borderLeft: '1px solid #E4E1DB',
       borderBottom: '1px solid #E4E1DB',

--- a/src/components/ToggleFullscreenButton.tsx
+++ b/src/components/ToggleFullscreenButton.tsx
@@ -6,21 +6,25 @@ import React from 'react';
 const FullscreenIconButton = withStyles((theme: Theme) => ({
   root: {
     marginLeft: 'auto',
-    // TODO: set negative padding?
     padding: 0,
     borderRadius: 0,
     cursor: 'pointer',
     '& svg': {
       color: theme.palette.primary.main,
-      // TODO: resize on fullscreen
-      height: '40px',
-      width: '40px',
       '&:hover': {
         color: theme.palette.text.primary,
       },
     },
   },
 }))(IconButton);
+
+const CloseFullscreenIcon = withStyles({
+  root: { height: '60px', width: '60px' },
+})(FullscreenExit);
+
+const OpenFullscreenIcon = withStyles({
+  root: { height: '42px', width: '42px' },
+})(Fullscreen);
 
 interface ToggleFullscreenButtonProps {
   isFullscreen: boolean;
@@ -43,7 +47,7 @@ export function ToggleFullscreenButton({
       disableRipple
       size="small"
     >
-      {isFullscreen ? <FullscreenExit /> : <Fullscreen />}
+      {isFullscreen ? <CloseFullscreenIcon /> : <OpenFullscreenIcon />}
     </FullscreenIconButton>
   );
 }

--- a/src/components/ToggleFullscreenButton.tsx
+++ b/src/components/ToggleFullscreenButton.tsx
@@ -1,0 +1,49 @@
+import { Theme, withStyles } from '@material-ui/core';
+import IconButton from '@material-ui/core/IconButton';
+import { Fullscreen, FullscreenExit } from '@material-ui/icons';
+import React from 'react';
+
+const FullscreenIconButton = withStyles((theme: Theme) => ({
+  root: {
+    marginLeft: 'auto',
+    // TODO: set negative padding?
+    padding: 0,
+    borderRadius: 0,
+    cursor: 'pointer',
+    '& svg': {
+      color: theme.palette.primary.main,
+      // TODO: resize on fullscreen
+      height: '40px',
+      width: '40px',
+      '&:hover': {
+        color: theme.palette.text.primary,
+      },
+    },
+  },
+}))(IconButton);
+
+interface ToggleFullscreenButtonProps {
+  isFullscreen: boolean;
+  onChange: () => void;
+}
+
+export function ToggleFullscreenButton({
+  isFullscreen,
+  onChange,
+}: ToggleFullscreenButtonProps) {
+  const altText = isFullscreen
+    ? 'Exit stor størrelse'
+    : 'Utvid til stor størrelse';
+
+  return (
+    <FullscreenIconButton
+      aria-label={altText}
+      title={altText}
+      onClick={onChange}
+      disableRipple
+      size="small"
+    >
+      {isFullscreen ? <FullscreenExit /> : <Fullscreen />}
+    </FullscreenIconButton>
+  );
+}

--- a/src/data/DDChart.tsx
+++ b/src/data/DDChart.tsx
@@ -1,17 +1,24 @@
 import React, { useState } from 'react';
-import { Fullscreen, FullscreenExit } from '@material-ui/icons';
-import { Theme, withStyles, createStyles, makeStyles } from '@material-ui/core';
+import { BarChart, Fullscreen, FullscreenExit } from '@material-ui/icons';
+import {
+  Theme,
+  withStyles,
+  createStyles,
+  makeStyles,
+  ButtonGroup,
+} from '@material-ui/core';
 import { GridItemHeader, GridItemContent } from '../components/GridItem';
 import DropdownPicker from '../components/DropdownPicker';
 import Line from './components/Line';
 import Bar from './components/Bar';
 import PercentArea from './components/PercentArea';
 import Pie from './components/Pie';
-import { DDComponentProps } from './types';
 import BigChart from '../components/BigChart';
 import { ErrorText } from '../components/ErrorText';
 import Sunburst from './components/Sunburst';
 import Radar from './components/Radar';
+import { DDComponentProps, DDPassProps } from './types';
+import Button from '@material-ui/core/Button';
 
 const usePlaceholderStyle = makeStyles(() =>
   createStyles({
@@ -100,8 +107,7 @@ export default function DDChart({
   description,
   props,
 }: DDComponentProps) {
-  const { componentType, setNames, sets } = payload as {
-    componentType: string;
+  const { setNames, sets } = payload as {
     setNames: string[];
     sets: { [key: string]: any };
   };
@@ -109,15 +115,48 @@ export default function DDChart({
     setNames && setNames.length > 0 ? setNames[0] : ''
   );
   const [big, setBig] = useState(false);
-  const ChartComponent = getChartComponent(componentType) as (
-    props: any
-  ) => JSX.Element;
+  const [selectedChart, setSelectedChart] = useState<number>(0);
 
-  const onChange = (value: any) => {
+  const ChartComponent = getChartComponent(
+    props.chartVariants[selectedChart].chartType
+  );
+  const passProps = props.chartVariants[selectedChart].chartProps;
+
+  const handleSetChange = (value: any) => {
     setSet(value as string);
   };
 
   const setNamesLength = payload.setNames ? payload.setNames.length : 0;
+
+  const generateChartTypeToggle = (
+    chartVariants: Array<{
+      chartType: string;
+      chartProps: DDPassProps;
+    }>
+  ) => {
+    if (chartVariants.length > 1) {
+      return (
+        <ButtonGroup>
+          {chartVariants.map((chartVariant, chartIndex) => {
+            // const chartTypeInfo = getChartTypeInfo(chartVariant.chartType);
+            // const ChartTypeIcon = chartTypeInfo.icon;
+            return (
+              <Button
+                key={chartIndex}
+                onClick={() => setSelectedChart(chartIndex)}
+                disabled={selectedChart === chartIndex}
+                // aria-label={chartTypeInfo.label}
+                startIcon={<BarChart />}
+              >
+                Visning {chartIndex + 1}
+              </Button>
+            );
+          })}
+        </ButtonGroup>
+      );
+    }
+    return null;
+  };
 
   const GridItem = () => {
     const altText = big ? 'Exit stor størrelse' : 'Utvid til stor størrelse';
@@ -127,7 +166,7 @@ export default function DDChart({
           {setNamesLength > 1 ? (
             <DropdownPicker
               values={setNames}
-              onChange={onChange}
+              onChange={handleSetChange}
               selected={set}
               big={big}
             />
@@ -142,7 +181,8 @@ export default function DDChart({
                 <LargerIcon onClick={() => setBig(true)} />
               )}
             </span>
-            <ChartComponent big={big} data={sets[set]} {...props} />
+            <ChartComponent big={big} data={sets[set]} {...passProps} />
+            {generateChartTypeToggle(props.chartVariants)}
           </GridItemContent>
         ) : (
           <ErrorText />

--- a/src/data/DDChart.tsx
+++ b/src/data/DDChart.tsx
@@ -17,7 +17,7 @@ import { ToggleFullscreenButton } from '../components/ToggleFullscreenButton';
 
 export type ChartVariant = 'Line' | 'Bar' | 'Pie' | 'Radar' | 'Sunburst';
 
-export interface ChartDetails {
+export interface ChartComponentInfo {
   type: ChartVariant;
   props: DDPassProps;
 }
@@ -48,7 +48,7 @@ export default function DDChart({
   const [big, setBig] = useState<boolean>(false);
   const [chartVariantIdx, setChartVariantIdx] = useState<number>(0);
 
-  const chartVariants = props.chartVariants as Array<ChartDetails>;
+  const chartVariants = props.chartVariants as Array<ChartComponentInfo>;
   const { type: chartVariantToRender, props: chartProps } = chartVariants[
     chartVariantIdx
   ];
@@ -81,6 +81,7 @@ export default function DDChart({
                   chartVariants={chartVariants}
                   selected={chartVariantIdx}
                   onChange={setChartVariantIdx}
+                  big={big}
                 />
               ) : null}
               <ToggleFullscreenButton

--- a/src/data/DDChart.tsx
+++ b/src/data/DDChart.tsx
@@ -3,7 +3,6 @@ import { GridItemHeader, GridItemContent } from '../components/GridItem';
 import DropdownPicker from '../components/DropdownPicker';
 import Line from './components/Line';
 import Bar from './components/Bar';
-import PercentArea from './components/PercentArea';
 import Pie from './components/Pie';
 import BigChart from '../components/BigChart';
 import { ErrorText } from '../components/ErrorText';
@@ -16,13 +15,7 @@ import {
 } from '../components/ChartDisplayOptions';
 import { ToggleFullscreenButton } from '../components/ToggleFullscreenButton';
 
-export type ChartVariant =
-  | 'Line'
-  | 'Bar'
-  | 'Pie'
-  | 'Radar'
-  | 'Sunburst'
-  | 'PercentArea';
+export type ChartVariant = 'Line' | 'Bar' | 'Pie' | 'Radar' | 'Sunburst';
 
 export interface ChartDetails {
   type: ChartVariant;
@@ -37,7 +30,6 @@ const chartComponents: {
   Pie: Pie,
   Radar: Radar,
   Sunburst: Sunburst,
-  PercentArea: PercentArea,
 };
 
 export default function DDChart({

--- a/src/data/components/Bar.tsx
+++ b/src/data/components/Bar.tsx
@@ -26,7 +26,7 @@ export default function Bar({
         data={data}
         keys={yLabels}
         indexBy={dataKey}
-        margin={{ top: 0, right: 20, bottom: 20, left: 40 }}
+        margin={{ top: 10, right: 20, bottom: 25, left: 40 }}
         padding={0.1}
         valueScale={{ type: 'linear' }}
         colors={colors}

--- a/src/data/components/Bar.tsx
+++ b/src/data/components/Bar.tsx
@@ -13,12 +13,7 @@ interface BarChartsProps {
   big?: boolean;
 }
 
-export default function Bar({
-  data,
-  yLabels,
-  dataKey = 'x',
-  big,
-}: BarChartsProps) {
+export default function Bar({ data, yLabels, dataKey, big }: BarChartsProps) {
   const height = big ? '400px' : '300px';
   return (
     <div style={{ height, width: '100%' }}>

--- a/src/data/components/Line.tsx
+++ b/src/data/components/Line.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import { ResponsiveLine } from '@nivo/line';
 import { colors } from './common';
 interface LineChartsProps {
-  yLabels?: string[];
-  dataKey?: string;
   data: any;
   big?: boolean;
 }

--- a/src/data/components/Pie.tsx
+++ b/src/data/components/Pie.tsx
@@ -8,17 +8,12 @@ type PieChartsData = {
 
 interface PieChartsProps {
   data: PieChartsData[];
-  groupKey?: string;
-  valueKey?: string;
+  groupKey: string;
+  valueKey: string;
   big?: boolean;
 }
 
-export default function Pie({
-  data,
-  groupKey = 'group',
-  valueKey = 'value',
-  big,
-}: PieChartsProps) {
+export default function Pie({ data, groupKey, valueKey, big }: PieChartsProps) {
   const height = big ? '400px' : '300px';
   return (
     <div style={{ height, width: '100%' }}>

--- a/src/data/components/Radar.tsx
+++ b/src/data/components/Radar.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import React from 'react';
 import { colors } from './common';
 import { ResponsiveRadar } from '@nivo/radar';
@@ -9,8 +8,8 @@ type RadarChartsData = {
 
 interface RadarChartsProps {
   data: RadarChartsData[];
-  groupKey?: string;
-  valueKey?: string[];
+  groupKey: string;
+  valueKey: string[];
   big?: boolean;
 }
 
@@ -18,8 +17,8 @@ const RadarChartColors = colors.filter((_, k) => k !== 1);
 
 export default function Radar({
   data,
-  groupKey = 'kategori',
-  valueKey = ['motivasjon','kompetanse'],
+  groupKey,
+  valueKey,
   big,
 }: RadarChartsProps) {
   const height = big ? '400px' : '300px';
@@ -29,7 +28,7 @@ export default function Radar({
         data={data}
         keys={valueKey}
         indexBy={groupKey}
-        maxValue='5'
+        maxValue={5}
         margin={{ top: 50, right: 10, bottom: 50, left: 10 }}
         curve="linearClosed"
         borderWidth={2}
@@ -41,31 +40,29 @@ export default function Radar({
         dotColor={{ theme: 'background' }}
         dotBorderWidth={2}
         enableDotLabel={false}
-        dotLabel = { props => props.value.toFixed(1) }
+        dotLabel={({ value }: { value: number }) => value.toFixed(1)}
         dotLabelYOffset={-12}
         colors={RadarChartColors}
         fillOpacity={0.25}
         blendMode="multiply"
         animate={true}
-        motionConfig="wobbly"
         isInteractive={true}
-        tooltipFormat = {
-          value => 
+        tooltipFormat={(value) =>
           `${Number(value).toLocaleString('no-NO', {
-            maximumFractionDigits: 2
+            maximumFractionDigits: 2,
           })}`
         }
         legends={[
           {
-              anchor: 'bottom',
-              direction: 'row',
-              translateY: -48,
-              itemWidth: 80,
-              itemHeight: 20,
-              itemTextColor: '#999',
-              symbolSize: 12,
-              symbolShape: 'circle'
-          }
+            anchor: 'bottom',
+            direction: 'row',
+            translateY: -48,
+            itemWidth: 80,
+            itemHeight: 20,
+            itemTextColor: '#999',
+            symbolSize: 12,
+            symbolShape: 'circle',
+          },
         ]}
       />
     </div>

--- a/src/data/components/Sunburst.tsx
+++ b/src/data/components/Sunburst.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import React from 'react';
 import { colors } from './common';
-import { ResponsiveSunburst } from '@nivo/sunburst';
+import { ResponsiveSunburst, NormalizedDatum } from '@nivo/sunburst';
 
 type SunburstChartsData = {
   [key: string]: string | number | Array<SunburstChartsData>;
@@ -9,8 +9,7 @@ type SunburstChartsData = {
 
 interface SunburstChartsProps {
   data: SunburstChartsData[];
-  groupKey?: string;
-  valueKey?: string;
+  groupKey: string;
   big?: boolean;
 }
 
@@ -25,11 +24,7 @@ function getParentSize(total, child) {
   return total + child['size'];
 }
 
-export default function Sunburst({
-  data,
-  groupKey = 'kategori',
-  big,
-}: SunburstChartsProps) {
+export default function Sunburst({ data, groupKey, big }: SunburstChartsProps) {
   const height = big ? '400px' : '300px';
 
   const CustomTooltip = ({

--- a/src/data/types.tsx
+++ b/src/data/types.tsx
@@ -5,7 +5,7 @@ export interface DDComponentProps {
   payload: DDPayload;
   title: string;
   description?: string;
-  props?: DDPassProps;
+  props: DDPassProps;
 }
 
 export interface DDItemProps {

--- a/src/pages/Competence.tsx
+++ b/src/pages/Competence.tsx
@@ -29,8 +29,8 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Radar',
-              chartProps: {
+              type: 'Radar',
+              props: {
                 groupKey: 'kategori',
                 valueKey: ['motivasjon', 'kompetanse'],
               },
@@ -47,8 +47,9 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Radar',
-              chartProps: {
+              type: 'Radar',
+              props: {
+                groupKey: 'kategori',
                 valueKey: ['kompetanse'],
               },
             },
@@ -64,15 +65,15 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Bar',
-              chartProps: {
+              type: 'Bar',
+              props: {
                 dataKey: 'years',
                 yLabels: ['count'],
               },
             },
             {
-              chartType: 'Pie',
-              chartProps: {
+              type: 'Pie',
+              props: {
                 groupKey: 'years',
                 valueKey: ['count'],
               },
@@ -89,8 +90,8 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Bar',
-              chartProps: {
+              type: 'Bar',
+              props: {
                 dataKey: 'age',
                 yLabels: ['count'],
               },
@@ -107,11 +108,7 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Line',
-              chartProps: {
-                dataKey: 'week',
-                yLabels: ['used_hrs'],
-              },
+              type: 'Line',
             },
           ],
         }}
@@ -126,7 +123,7 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Line',
+              type: 'Line',
             },
           ],
         }}
@@ -140,8 +137,8 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Pie',
-              chartProps: {
+              type: 'Pie',
+              props: {
                 groupKey: 'degree',
                 valueKey: 'count',
               },
@@ -159,10 +156,10 @@ export default function Competence() {
         dataComponentProps={{
           chartVariants: [
             {
-              chartType: 'Sunburst',
-              chartProps: {
-                dataKey: 'section',
+              type: 'Sunburst',
+              props: {
                 yLabels: ['value'],
+                groupKey: 'kategori',
               },
             },
           ],

--- a/src/pages/Competence.tsx
+++ b/src/pages/Competence.tsx
@@ -26,6 +26,17 @@ export default function Competence() {
         title="Kompetansemengde"
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
+        dataComponentProps={{
+          chartVariants: [
+            {
+              chartType: 'Radar',
+              chartProps: {
+                groupKey: 'kategori',
+                valueKey: ['motivasjon', 'kompetanse'],
+              },
+            },
+          ],
+        }}
       />
 
       <DDItem
@@ -34,7 +45,14 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          valueKey: ['kompetanse'],
+          chartVariants: [
+            {
+              chartType: 'Radar',
+              chartProps: {
+                valueKey: ['kompetanse'],
+              },
+            },
+          ],
         }}
       />
 
@@ -44,8 +62,22 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          dataKey: 'years',
-          yLabels: ['count'],
+          chartVariants: [
+            {
+              chartType: 'Bar',
+              chartProps: {
+                dataKey: 'years',
+                yLabels: ['count'],
+              },
+            },
+            {
+              chartType: 'Pie',
+              chartProps: {
+                groupKey: 'years',
+                valueKey: ['count'],
+              },
+            },
+          ],
         }}
       />
 
@@ -55,8 +87,15 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          dataKey: 'age',
-          yLabels: ['count'],
+          chartVariants: [
+            {
+              chartType: 'Bar',
+              chartProps: {
+                dataKey: 'age',
+                yLabels: ['count'],
+              },
+            },
+          ],
         }}
       />
 
@@ -66,17 +105,31 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          dataKey: 'week',
-          yLabels: ['used_hrs'],
+          chartVariants: [
+            {
+              chartType: 'Line',
+              chartProps: {
+                dataKey: 'week',
+                yLabels: ['used_hrs'],
+              },
+            },
+          ],
         }}
       />
 
       <DDItem
         url="/api/data/fagEvents"
         title="Fag og hendelser"
-        description="Hver vertikal akse viser antall unike hendelser per måned fra Google kalenderne Knowit Events og Knowit Fagkalender."
+        description="Hver vertikal akse viser antall unike hendelser per måned fra Google kalenderne Knowit Events og Knowit Fagkalender."
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
+        dataComponentProps={{
+          chartVariants: [
+            {
+              chartType: 'Line',
+            },
+          ],
+        }}
       />
 
       <DDItem
@@ -85,21 +138,34 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          groupKey: 'degree',
-          valueKey: 'count',
+          chartVariants: [
+            {
+              chartType: 'Pie',
+              chartProps: {
+                groupKey: 'degree',
+                valueKey: 'count',
+              },
+            },
+          ],
         }}
       />
 
       <DDItem
         url="/api/data/competenceMapping"
         title="Kompetansekartlegging"
-        description="Grafen viser gjennomsnittlig score på
-        kompetanse/motivasjon innenfor hver av hovedkategoriene. I tillegg vises gjennomsnittlig score for hver underkategori og forholdet mellom underkategoriene i samme hovedkategori."
+        description="Grafen viser gjennomsnittlig score på kompetanse/motivasjon innenfor hver av hovedkategoriene. I tillegg vises gjennomsnittlig score for hver underkategori og forholdet mellom underkategoriene i samme hovedkategori."
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          dataKey: 'section',
-          yLabels: ['value'],
+          chartVariants: [
+            {
+              chartType: 'Sunburst',
+              chartProps: {
+                dataKey: 'section',
+                yLabels: ['value'],
+              },
+            },
+          ],
         }}
       />
       <DDItem

--- a/src/pages/Competence.tsx
+++ b/src/pages/Competence.tsx
@@ -44,8 +44,8 @@ export default function Competence() {
         Component={DDChart}
         SkeletonComponent={ChartSkeleton}
         dataComponentProps={{
-          groupKey: 'years',
-          valueKey: ['count'],
+          dataKey: 'years',
+          yLabels: ['count'],
         }}
       />
 

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -220,8 +220,8 @@ export default function EmployeeSite() {
               dataComponentProps={{
                 chartVariants: [
                   {
-                    chartType: 'Radar',
-                    chartProps: {
+                    type: 'Radar',
+                    props: {
                       groupKey: 'kategori',
                       valueKey: ['motivasjon', 'kompetanse'],
                     },

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -218,7 +218,15 @@ export default function EmployeeSite() {
               Component={DDChart}
               SkeletonComponent={ChartSkeleton}
               dataComponentProps={{
-                valueKey: ['motivasjon', 'kompetanse'],
+                chartVariants: [
+                  {
+                    chartType: 'Radar',
+                    chartProps: {
+                      groupKey: 'kategori',
+                      valueKey: ['motivasjon', 'kompetanse'],
+                    },
+                  },
+                ],
               }}
             />
           )}


### PR DESCRIPTION
* Changed the default chart type for experience distribution ("Erfaring") from pie to bar.
* Added possibility of showing multiple chart types for a data set. 
   * Chart type is no longer defined in backend, but as array in `pages/Compentence.tsx` along with per-chart props.
   * If more than one chart variant is defined, buttons for toggling between chart variants is displayed.