### PR TITLE
added bar-visualization for competence mapping data

### DIFF
--- a/backend/repository/data.js
+++ b/backend/repository/data.js
@@ -540,10 +540,7 @@ exports.competenceMapping = async ({ data }) => {
 
   const competenceCategories = (data) => {
     // Categories structure
-    const output = {
-      kategori: 'kompetansekartlegging',
-      children: [],
-    };
+    const output = [];
 
     // Get the main categories
     const mainCategories = new Set(
@@ -579,7 +576,7 @@ exports.competenceMapping = async ({ data }) => {
       });
 
       categoryObject.verdi = avgValue;
-      output.children.push(categoryObject);
+      output.push(categoryObject);
     });
 
     return output;

--- a/src/data/components/Sunburst.tsx
+++ b/src/data/components/Sunburst.tsx
@@ -26,6 +26,10 @@ function getParentSize(total, child) {
 
 export default function Sunburst({ data, groupKey, big }: SunburstChartsProps) {
   const height = big ? '400px' : '300px';
+  const formatedData = {
+    kategori: 'kompetansekartlegging',
+    children: data,
+  };
 
   const CustomTooltip = ({
     id,
@@ -36,7 +40,7 @@ export default function Sunburst({ data, groupKey, big }: SunburstChartsProps) {
     const childValue =
       depth === 1
         ? value
-        : data.children
+        : formatedData.children
             .find((kategori) => kategori.kategori === ancestor.id)
             .children.find((kategori) => kategori.kategori === id).verdi;
 
@@ -50,7 +54,7 @@ export default function Sunburst({ data, groupKey, big }: SunburstChartsProps) {
   return (
     <div style={{ height, width: '100%' }}>
       <ResponsiveSunburst
-        data={data}
+        data={formatedData}
         margin={{ top: 10, right: 10, bottom: 30, left: 10 }}
         identity={groupKey}
         cornerRadius={2}

--- a/src/data/components/Sunburst.tsx
+++ b/src/data/components/Sunburst.tsx
@@ -27,7 +27,6 @@ function getParentSize(total, child) {
 export default function Sunburst({ data, groupKey, big }: SunburstChartsProps) {
   const height = big ? '400px' : '300px';
   const formatedData = {
-    kategori: 'kompetansekartlegging',
     children: data,
   };
 

--- a/src/pages/Competence.tsx
+++ b/src/pages/Competence.tsx
@@ -158,8 +158,15 @@ export default function Competence() {
             {
               type: 'Sunburst',
               props: {
-                yLabels: ['value'],
+                yLabels: ['verdi'],
                 groupKey: 'kategori',
+              },
+            },
+            {
+              type: 'Bar',
+              props: {
+                dataKey: 'kategori',
+                yLabels: ['verdi'],
               },
             },
           ],


### PR DESCRIPTION
Første del av [issue #351](https://github.com/knowit/Dataplattform-issues/issues/351). 

> Endringer ønskes:
>Vise relativ størrelse på et komptetanseområde ved søylestørrelse
>Vise antall som har gitt seg selv >3 i score og/eller precentilscore på samme måte som radar-grafen

Hvordan vi skal løse resten må diskuteres