### PR TITLE
Hotfix: Fixes for linter warnings (blocking deployment)

### DIFF
--- a/src/components/EmployeeInfo.tsx
+++ b/src/components/EmployeeInfo.tsx
@@ -136,7 +136,6 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function EmployeeInfo({
   data,
   id,
-  rowStates,
   dispatch,
 }: {
   data: {

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -319,7 +319,8 @@ export default function EmployeeSite() {
         {pending || !data ? (
           <p>loading....</p>
         ) : (
-          Object.entries(data!.links).map((link) => (
+          data &&
+          Object.entries(data.links).map((link) => (
             <p key={link[1]}>
               <a href={link[1]}>{link[0]}</a>
             </p>


### PR DESCRIPTION
Upgrading the frontend dependencies led to stricter handling of linter warnings. They are now treated as errors in the CI build process, blocking the build and deployment of the frontend. This PR fixes the two linter warnings currently in the frontend code.