### PR TITLE
Fixing the expanded rows error

### DIFF
--- a/src/components/EmployeeInfo.tsx
+++ b/src/components/EmployeeInfo.tsx
@@ -176,7 +176,9 @@ export default function EmployeeInfo({ data, id, setRowHeight }: Props) {
       const newHeight = getOffsetHeight(targetRef) + 72
       setRowHeight(id, newHeight)
     }
-  }, [pending, targetRef, id, setRowHeight])
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pending, targetRef, id])
 
   return (
     <div ref={setRef} className={classes.root}>

--- a/src/data/components/table/DataTable.tsx
+++ b/src/data/components/table/DataTable.tsx
@@ -245,7 +245,7 @@ function MuiVirtualizedTable({
           RenderExpanded && (
             <RenderExpanded
               data={rowData[0]}
-              setHeight={setExpandedRowHeight}
+              setRowHeight={setExpandedRowHeight}
               callBack={() => {
                 ArrayRef.recomputeRowHeights()
                 ArrayRef.forceUpdate()


### PR DESCRIPTION
Ved fiksing av pr kommentarer ble de lagt til en dependency i useEffecten som gjør at expandedrows ikke fungerer og crasher nettsiden.