### PR TITLE
Fixed path patterns that should trigger pull request workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -7,7 +7,7 @@ defaults:
 on:
   pull_request:
     paths:
-      - 'backend/*/**'
+      - 'backend/**'
 
 jobs:
   test:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -6,8 +6,8 @@ defaults:
 
 on:
   pull_request:
-    paths:
-      - '*/**'
+    paths-ignore:
+      - 'backend/**'
 
 jobs:
   # test:


### PR DESCRIPTION
The path patterns defined for triggering GitHub Actions on pull requests were not matching correctly. 
* All PRs triggered the frontend workflow, even if changes only were made in the `backend` folder.
* PRs with changes in files located at the root of the `backend` folder (e.g. in the `backend/package.json` file) did not trigger the backend workflow. Only changes made in subfolders of the `backend` folder triggered this workflow.

See the workflows here: https://github.com/knowit/folk-webapp/actions (defined in the `.github` folder in the project)

The changed patterns should (hopefully) work as follows:
* PRs that contain changes in the `backend` folder should trigger the backend workflow
* PRs that contain changes outside the `backend` folder should trigger the frontend workflow
* PRs that contain changes in **and** outside the `backend` folder should trigger both workflows