### PR TITLE
Refactor/empdata endpoint

### DIFF
--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -687,12 +687,24 @@ export const employeeProfileReports = ({
 /** Dette endepunktet henter data om en enkelt person for å fylle opp sidene for hver enkelt ansatt.  */
 export const employeeProfile = async ({ data }: EmployeeData) => {
   const [employeeSkills, workExperience, employeeInformation] = data
+
+  // TODO: we should probably send a proper response to the frontend if there is no employee with the given email
+  // if (!employeeInformation || employeeInformation.length === 0) {
+  //   throw reporting({ status: 404, message: 'No employee information found' })
+  // }
+
   const employee = mergeEmployeesByCustomers(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
-    ...employee,
-    image: getStorageUrl(employee.image_key),
+    user_id: employee?.user_id,
+    guid: employee?.guid,
+    navn: employee?.navn,
+    manager: employee?.manager,
+    title: employee?.title,
+    degree: employee?.degree,
+    email: employee?.email,
+    image: getStorageUrl(employee?.image_key),
     workExperience,
     tags: {
       skills: skill?.split(';') ?? [],
@@ -702,7 +714,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
     links: Object.fromEntries(
       cvs.map(([lang, format]) => [
         `${lang}_${format}`,
-        employee.link.replace('{LANG}', lang).replace('{FORMAT}', format),
+        employee?.link?.replace('{LANG}', lang).replace('{FORMAT}', format),
       ])
     ),
   }

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -709,6 +709,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
     degree: employee?.degree,
     email: employee?.email,
     image: getStorageUrl(employee?.image_key),
+    customers: employee?.customers,
     workExperience,
     tags: {
       skills: skill?.split(';') ?? [],

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -688,12 +688,17 @@ export const employeeProfileReports = ({
 export const employeeProfile = async ({ data }: EmployeeData) => {
   const [employeeSkills, workExperience, employeeInformation] = data
   const employee = mergeEmployeesByCustomers(employeeInformation)[0]
+  const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
-    employee,
+    ...employee,
     image: getStorageUrl(employee.image_key),
     workExperience,
-    tags: employeeSkills[0],
+    tags: {
+      skills: skill?.split(';') ?? [],
+      languages: language?.split(';') ?? [],
+      roles: role?.split(';') ?? [],
+    },
     links: Object.fromEntries(
       cvs.map(([lang, format]) => [
         `${lang}_${format}`,

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -4,7 +4,7 @@ import {
   getEventSet,
   getWeek,
   getYear,
-  mergeEmployeesByCustomers,
+  mergeCustomersForEmployees,
   range,
   statusColorCode,
   sum,
@@ -156,7 +156,7 @@ type EmployeeWorkStatus = {
 export const employeeTable = async ({ data }: EmployeeTable) => {
   const [allEmployees, motivationAndCompetence, jobRotation, employeeStatus] =
     data
-  const employeesWithMergedCustomers = mergeEmployeesByCustomers(allEmployees)
+  const employeesWithMergedCustomers = mergeCustomersForEmployees(allEmployees)
 
   return employeesWithMergedCustomers.map((employee) => ({
     rowId: uuid(),
@@ -286,13 +286,14 @@ type EmployeeData = {
   data: [EmployeeSkills[], WorkExperience[], EmployeeInformation[]]
 }
 
-/** Dette endepunktet henter mer data om ansatte.
- *  Arbeidserfaring, ferdigheter, språk,  utdanning og roller fra CV-partner og nærmeste leder fra AD,
- *  Brukes i EmployeeInfo.tsx (utvidet tabell) og EmployeeSite.tsx
+/**
+ * Dette endepunktet henter mer data om ansatte. Arbeidserfaring, ferdigheter,
+ * språk,  utdanning og roller fra CV-partner og nærmeste leder fra AD.
+ * Brukes i EmployeeInfo.tsx (utvidet tabell).
  */
 export const employeeCompetence = async ({ data }: EmployeeData) => {
   const [resSkills, resEmp, resComp] = data
-  const mergedRes = mergeEmployeesByCustomers(resComp)
+  const mergedRes = mergeCustomersForEmployees(resComp)
 
   const mapTags = (skills: EmployeeSkills[]) => {
     const mappedSkills =
@@ -684,7 +685,10 @@ export const employeeProfileReports = ({
     filter: { email },
   },
 ]
-/** Dette endepunktet henter data om en enkelt person for å fylle opp sidene for hver enkelt ansatt.  */
+
+/**
+ * Dette endepunktet henter data om en enkelt person for å fylle opp sidene for hver enkelt ansatt.
+ */
 export const employeeProfile = async ({ data }: EmployeeData) => {
   const [employeeSkills, workExperience, employeeInformation] = data
 
@@ -693,7 +697,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
   //   throw reporting({ status: 404, message: 'No employee information found' })
   // }
 
-  const employee = mergeEmployeesByCustomers(employeeInformation)[0]
+  const employee = mergeCustomersForEmployees(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -692,24 +692,23 @@ export const employeeProfileReports = ({
 export const employeeProfile = async ({ data }: EmployeeData) => {
   const [employeeSkills, workExperience, employeeInformation] = data
 
-  // TODO: we should probably send a proper response to the frontend if there is no employee with the given email
-  // if (!employeeInformation || employeeInformation.length === 0) {
-  //   throw reporting({ status: 404, message: 'No employee information found' })
-  // }
+  if (!employeeInformation || employeeInformation.length === 0) {
+    return
+  }
 
   const employee = mergeCustomersForEmployees(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
-    user_id: employee?.user_id,
-    guid: employee?.guid,
-    navn: employee?.navn,
-    manager: employee?.manager,
-    title: employee?.title,
-    degree: employee?.degree,
-    email: employee?.email,
-    image: getStorageUrl(employee?.image_key),
-    customers: employee?.customers,
+    user_id: employee.user_id,
+    guid: employee.guid,
+    navn: employee.navn,
+    manager: employee.manager,
+    title: employee.title,
+    degree: employee.degree,
+    email: employee.email,
+    image: getStorageUrl(employee.image_key),
+    customers: employee.customers,
     workExperience,
     tags: {
       skills: skill?.split(';') ?? [],
@@ -719,7 +718,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
     links: Object.fromEntries(
       cvs.map(([lang, format]) => [
         `${lang}_${format}`,
-        employee?.link?.replace('{LANG}', lang).replace('{FORMAT}', format),
+        employee.link?.replace('{LANG}', lang).replace('{FORMAT}', format),
       ])
     ),
   }

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -4,7 +4,7 @@ import {
   getEventSet,
   getWeek,
   getYear,
-  mergeEmployees,
+  mergeEmployeesByCustomers,
   range,
   statusColorCode,
   sum,
@@ -156,9 +156,9 @@ type EmployeeWorkStatus = {
 export const employeeTable = async ({ data }: EmployeeTable) => {
   const [allEmployees, motivationAndCompetence, jobRotation, employeeStatus] =
     data
-  const mergedEmployees = mergeEmployees(allEmployees)
+  const employeesWithMergedCustomers = mergeEmployeesByCustomers(allEmployees)
 
-  return mergedEmployees.map((employee) => ({
+  return employeesWithMergedCustomers.map((employee) => ({
     rowId: uuid(),
     rowData: [
       {
@@ -175,7 +175,7 @@ export const employeeTable = async ({ data }: EmployeeTable) => {
       employee.title,
 
       findProjectStatusForEmployee(jobRotation, employeeStatus, employee.guid),
-      employee.customerArray.reduce((prevCustomer, thisCustomer) => {
+      employee.customers.reduce((prevCustomer, thisCustomer) => {
         if (thisCustomer.weight < prevCustomer.weight) {
           return thisCustomer
         } else {
@@ -292,7 +292,7 @@ type EmployeeData = {
  */
 export const employeeCompetence = async ({ data }: EmployeeData) => {
   const [resSkills, resEmp, resComp] = data
-  const mergedRes = mergeEmployees(resComp)
+  const mergedRes = mergeEmployeesByCustomers(resComp)
 
   const mapTags = (skills: EmployeeSkills[]) => {
     const mappedSkills =
@@ -668,7 +668,7 @@ export const competenceAmount = async ({
   }
 }
 
-export const empDataReports = ({
+export const employeeProfileReports = ({
   parameters: { email } = {},
 }: ReportParams) => [
   {
@@ -685,26 +685,21 @@ export const empDataReports = ({
   },
 ]
 /** Dette endepunktet henter data om en enkelt person for å fylle opp sidene for hver enkelt ansatt.  */
-export const empData = async ({ data }: EmployeeData) => {
-  const [resSkills, resWork, resComp] = data
-  const emp = mergeEmployees(resComp)[0]
+export const employeeProfile = async ({ data }: EmployeeData) => {
+  const [employeeSkills, workExperience, employeeInformation] = data
+  const employee = mergeEmployeesByCustomers(employeeInformation)[0]
 
   return {
-    email_id: emp.email,
-    user_id: emp.user_id,
-    employee: emp,
-    image: getStorageUrl(emp.image_key),
-    workExperience: resWork,
-    tags: resSkills[0],
-    degree: resComp[0].degree,
-    manager: resComp[0].manager,
+    employee,
+    image: getStorageUrl(employee.image_key),
+    workExperience,
+    tags: employeeSkills[0],
     links: Object.fromEntries(
       cvs.map(([lang, format]) => [
         `${lang}_${format}`,
-        emp.link.replace('{LANG}', lang).replace('{FORMAT}', format),
+        employee.link.replace('{LANG}', lang).replace('{FORMAT}', format),
       ])
     ),
-    customerArray: emp.customerArray,
   }
 }
 

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -53,8 +53,6 @@ export const getWeek = (): string => {
 export const mergeEmployeesByCustomers = (
   employees: EmployeeInformation[]
 ): EmployeeWithMergedCustomers[] => {
-  const mergedEmployees = {}
-
   const employeesWithMergedCustomers = {}
 
   employees.forEach((employee) => {
@@ -64,7 +62,8 @@ export const mergeEmployeesByCustomers = (
       weight: employee.weight,
     }
 
-    const employeeToMerge = mergedEmployees[employee.guid] ?? employee
+    const employeeToMerge =
+      employeesWithMergedCustomers[employee.guid] ?? employee
     const customersForEmployee = employeeToMerge.customers ?? []
 
     employeesWithMergedCustomers[employee.guid] = {
@@ -72,6 +71,7 @@ export const mergeEmployeesByCustomers = (
       customers: [thisCustomer, ...customersForEmployee],
     }
   })
+
   return Object.values(employeesWithMergedCustomers)
 }
 

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -50,7 +50,13 @@ export const getWeek = (): string => {
   return currentWeekNumber.toString()
 }
 
-export const mergeEmployeesByCustomers = (
+/**
+ * Receives a list of employees, where each employee is listed once for each
+ * customer it is related to. This means that an employee might be listed more
+ * than once. The function merges the received employees and returns a list of
+ * distinct employees, each with a merged list of their related customers.
+ */
+export const mergeCustomersForEmployees = (
   employees: EmployeeInformation[]
 ): EmployeeWithMergedCustomers[] => {
   const employeesWithMergedCustomers = {}

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -22,8 +22,8 @@ export type EmployeeInformation = {
   work_order_description: string
 }
 
-type MergeEmployees = EmployeeInformation & {
-  customerArray: {
+type EmployeeWithMergedCustomers = EmployeeInformation & {
+  customers: {
     customer: string
     wordOrderDescription: string
     weight: number
@@ -50,12 +50,14 @@ export const getWeek = (): string => {
   return currentWeekNumber.toString()
 }
 
-export const mergeEmployees = (
-  allEmployees: EmployeeInformation[]
-): MergeEmployees[] => {
+export const mergeEmployeesByCustomers = (
+  employees: EmployeeInformation[]
+): EmployeeWithMergedCustomers[] => {
   const mergedEmployees = {}
 
-  allEmployees.forEach((employee) => {
+  const employeesWithMergedCustomers = {}
+
+  employees.forEach((employee) => {
     const thisCustomer = {
       customer: employee.customer,
       workOrderDescription: employee.work_order_description,
@@ -63,14 +65,14 @@ export const mergeEmployees = (
     }
 
     const employeeToMerge = mergedEmployees[employee.guid] ?? employee
-    const customersForEmployee = employeeToMerge.customerArray ?? []
+    const customersForEmployee = employeeToMerge.customers ?? []
 
-    mergedEmployees[employee.guid] = {
+    employeesWithMergedCustomers[employee.guid] = {
       ...employeeToMerge,
-      customerArray: [thisCustomer, ...customersForEmployee],
+      customers: [thisCustomer, ...customersForEmployee],
     }
   })
-  return Object.values(mergedEmployees)
+  return Object.values(employeesWithMergedCustomers)
 }
 
 export const statusColorCode = (

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -115,5 +115,5 @@ export const makeCvLink = (
   format: string,
   linkTemplate?: string
 ) => {
-  return linkTemplate.replace('{LANG}', lang).replace('{FORMAT}', format)
+  return linkTemplate?.replace('{LANG}', lang).replace('{FORMAT}', format)
 }

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -113,7 +113,7 @@ export const getCategoryScoresForEmployee = (
 export const makeCvLink = (
   lang: string,
   format: string,
-  linkTemplate: string
+  linkTemplate?: string
 ) => {
   return linkTemplate.replace('{LANG}', lang).replace('{FORMAT}', format)
 }

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -1,10 +1,11 @@
 import {
   CategoryScores,
+  Customer,
   EmployeeInformation,
   EmployeeMotivationAndCompetence,
+  EmployeeWithMergedCustomers,
   JobRotation,
   JobRotationStatus,
-  MergeEmployees,
 } from './employeesTypes'
 
 export const cvs = [
@@ -22,27 +23,28 @@ export const getStorageUrl = (key: string) => {
   }
 }
 
-export const mergeEmployees = (
-  allEmployees: EmployeeInformation[]
-): MergeEmployees[] => {
-  const mergedEmployees = {}
+export const mergeEmployeesByCustomers = (
+  employees: EmployeeInformation[]
+): EmployeeWithMergedCustomers[] => {
+  const employeesWithMergedCustomers = {}
 
-  allEmployees.forEach((employee) => {
-    const thisCustomer = {
+  employees.forEach((employee) => {
+    const thisCustomer: Customer = {
       customer: employee.customer,
       workOrderDescription: employee.work_order_description,
       weight: employee.weight,
     }
 
-    const employeeToMerge = mergedEmployees[employee.guid] ?? employee
-    const customersForEmployee = employeeToMerge.customerArray ?? []
+    const employeeToMerge: EmployeeWithMergedCustomers =
+      employeesWithMergedCustomers[employee.guid] ?? employee
+    const customersForEmployee = employeeToMerge.customers ?? []
 
-    mergedEmployees[employee.guid] = {
+    employeesWithMergedCustomers[employee.guid] = {
       ...employeeToMerge,
-      customerArray: [thisCustomer, ...customersForEmployee],
+      customers: [thisCustomer, ...customersForEmployee],
     }
   })
-  return Object.values(mergedEmployees)
+  return Object.values(employeesWithMergedCustomers)
 }
 
 export const findProjectStatusForEmployee = (
@@ -106,4 +108,12 @@ export const getCategoryScoresForEmployee = (
   })
 
   return [employeeMotivation, employeeCompetence]
+}
+
+export const makeCvLink = (
+  lang: string,
+  format: string,
+  linkTemplate: string
+) => {
+  return linkTemplate.replace('{LANG}', lang).replace('{FORMAT}', format)
 }

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -23,7 +23,13 @@ export const getStorageUrl = (key: string) => {
   }
 }
 
-export const mergeEmployeesByCustomers = (
+/**
+ * Receives a list of employees, where each employee is listed once for each
+ * customer it is related to. This means that an employee might be listed more
+ * than once. The function merges the received employees and returns a list of
+ * distinct employees, each with a merged list of their related customers.
+ */
+export const mergeCustomersForEmployees = (
   employees: EmployeeInformation[]
 ): EmployeeWithMergedCustomers[] => {
   const employeesWithMergedCustomers = {}

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -5,7 +5,7 @@ import {
   getCategoryScoresForEmployee,
   getStorageUrl,
   makeCvLink,
-  mergeEmployeesByCustomers,
+  mergeCustomersForEmployees,
 } from './aggregationHelpers'
 import {
   EmployeeExperience,
@@ -20,7 +20,7 @@ export const aggregateEmployeeTable = (
   jobRotationInformation
 ) => {
   const employeesWithMergedCustomers =
-    mergeEmployeesByCustomers(employeeInformation)
+    mergeCustomersForEmployees(employeeInformation)
   return employeesWithMergedCustomers.map((employee) => ({
     rowId: uuid(),
     rowData: [
@@ -120,7 +120,7 @@ export const aggregateEmployeeProfile = (
   workExperience: EmployeeExperience[],
   employeeInformation: EmployeeInformation[]
 ): EmployeeProfile => {
-  const employee = mergeEmployeesByCustomers(employeeInformation)[0]
+  const employee = mergeCustomersForEmployees(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -122,11 +122,17 @@ export const aggregateEmployeeProfile = (
 ): EmployeeProfile => {
   const employee = mergeEmployeesByCustomers(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
-  const { link: cvLinkTemplate, image_key } = employeeInformation[0]
 
   return {
-    ...employee,
-    image: getStorageUrl(image_key),
+    user_id: employee?.user_id,
+    guid: employee?.guid,
+    navn: employee?.navn,
+    manager: employee?.manager,
+    title: employee?.title,
+    degree: employee?.degree,
+    email: employee?.email,
+    image: getStorageUrl(employee?.image_key),
+    customers: employee?.customers,
     workExperience,
     tags: {
       skills: skill?.split(';') ?? [],
@@ -134,10 +140,10 @@ export const aggregateEmployeeProfile = (
       roles: role?.split(';') ?? [],
     },
     links: {
-      no_pdf: makeCvLink('no', 'pdf', cvLinkTemplate),
-      int_pdf: makeCvLink('int', 'pdf', cvLinkTemplate),
-      no_word: makeCvLink('no', 'word', cvLinkTemplate),
-      int_word: makeCvLink('int', 'word', cvLinkTemplate),
+      no_pdf: makeCvLink('no', 'pdf', employee?.link),
+      int_pdf: makeCvLink('int', 'pdf', employee?.link),
+      no_word: makeCvLink('no', 'word', employee?.link),
+      int_word: makeCvLink('int', 'word', employee?.link),
     },
   }
 }

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -12,6 +12,7 @@ import {
   EmployeeInformation,
   EmployeeProfile,
   EmployeeSkills,
+  WorkExperience,
 } from './employeesTypes'
 
 export const aggregateEmployeeTable = (
@@ -117,22 +118,26 @@ export const aggregateEmployeeRadar = (data: any) => {
 
 export const aggregateEmployeeProfile = (
   employeeSkills: EmployeeSkills[],
-  workExperience: EmployeeExperience[],
+  workExperience: WorkExperience[],
   employeeInformation: EmployeeInformation[]
 ): EmployeeProfile => {
+  if (employeeInformation.length === 0) {
+    return
+  }
+
   const employee = mergeCustomersForEmployees(employeeInformation)[0]
   const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
-    user_id: employee?.user_id,
-    guid: employee?.guid,
-    navn: employee?.navn,
-    manager: employee?.manager,
-    title: employee?.title,
-    degree: employee?.degree,
-    email: employee?.email,
-    image: getStorageUrl(employee?.image_key),
-    customers: employee?.customers,
+    user_id: employee.user_id,
+    guid: employee.guid,
+    navn: employee.navn,
+    manager: employee.manager,
+    title: employee.title,
+    degree: employee.degree,
+    email: employee.email,
+    image: getStorageUrl(employee.image_key),
+    customers: employee.customers,
     workExperience,
     tags: {
       skills: skill?.split(';') ?? [],
@@ -140,10 +145,10 @@ export const aggregateEmployeeProfile = (
       roles: role?.split(';') ?? [],
     },
     links: {
-      no_pdf: makeCvLink('no', 'pdf', employee?.link),
-      int_pdf: makeCvLink('int', 'pdf', employee?.link),
-      no_word: makeCvLink('no', 'word', employee?.link),
-      int_word: makeCvLink('int', 'word', employee?.link),
+      no_pdf: makeCvLink('no', 'pdf', employee.link),
+      int_pdf: makeCvLink('int', 'pdf', employee.link),
+      no_word: makeCvLink('no', 'word', employee.link),
+      int_word: makeCvLink('int', 'word', employee.link),
     },
   }
 }

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -7,7 +7,12 @@ import {
   makeCvLink,
   mergeEmployeesByCustomers,
 } from './aggregationHelpers'
-import { EmployeeExperience, EmployeeProfile } from './employeesTypes'
+import {
+  EmployeeExperience,
+  EmployeeInformation,
+  EmployeeProfile,
+  EmployeeSkills,
+} from './employeesTypes'
 
 export const aggregateEmployeeTable = (
   employeeInformation,
@@ -111,20 +116,28 @@ export const aggregateEmployeeRadar = (data: any) => {
 }
 
 export const aggregateEmployeeProfile = (
-  employeeSkills,
-  workExperience,
-  employeeInformation
+  employeeSkills: EmployeeSkills[],
+  workExperience: EmployeeExperience[],
+  employeeInformation: EmployeeInformation[]
 ): EmployeeProfile => {
+  const employee = mergeEmployeesByCustomers(employeeInformation)[0]
+  const { skill, language, role } = employeeSkills[0] ?? {}
+  const { link: cvLinkTemplate, image_key } = employeeInformation[0]
+
   return {
-    employee: mergeEmployeesByCustomers(employeeInformation)[0],
-    image: getStorageUrl(employeeInformation.image_key),
+    ...employee,
+    image: getStorageUrl(image_key),
     workExperience,
-    tags: employeeSkills[0],
+    tags: {
+      skills: skill?.split(';') ?? [],
+      languages: language?.split(';') ?? [],
+      roles: role?.split(';') ?? [],
+    },
     links: {
-      no_pdf: makeCvLink('no', 'pdf', employeeInformation.link),
-      int_pdf: makeCvLink('int', 'pdf', employeeInformation.link),
-      no_word: makeCvLink('no', 'word', employeeInformation.link),
-      int_word: makeCvLink('int', 'word', employeeInformation.link),
+      no_pdf: makeCvLink('no', 'pdf', cvLinkTemplate),
+      int_pdf: makeCvLink('int', 'pdf', cvLinkTemplate),
+      no_word: makeCvLink('no', 'word', cvLinkTemplate),
+      int_word: makeCvLink('int', 'word', cvLinkTemplate),
     },
   }
 }

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import { getReport } from '../../dataplattform/client'
 import { ParamError } from '../errorHandling'
 import {
-  aggregateEmpData,
+  aggregateEmployeeProfile,
   aggregateEmployeeExperience,
   aggregateEmployeeRadar,
   aggregateEmployeeTable,
@@ -140,7 +140,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
 )
 
 router.get<unknown, unknown, unknown, EmailParam>(
-  '/empData',
+  '/employeeProfile',
   async (req, res, next) => {
     try {
       if (!req.query.email) {
@@ -183,7 +183,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
           employeeInformationPromise,
         ])
 
-      const aggregatedData = aggregateEmpData(
+      const aggregatedData = aggregateEmployeeProfile(
         employeeSkills,
         workExperience,
         employeeInformation

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -7,7 +7,12 @@ import {
   aggregateEmployeeRadar,
   aggregateEmployeeTable,
 } from './employeesAggregation'
-import { CompetenceAreasResponse, EmployeeExperience } from './employeesTypes'
+import {
+  CompetenceAreasResponse,
+  EmployeeExperience,
+  EmployeeInformation,
+  EmployeeSkills,
+} from './employeesTypes'
 
 const router = express.Router()
 
@@ -152,7 +157,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
         throw err
       }
 
-      const employeeSkillsPromise = getReport<any[]>({
+      const employeeSkillsPromise = getReport<EmployeeSkills[]>({
         accessToken: req.accessToken,
         reportName: 'employeeSkills',
         queryParams: {
@@ -160,7 +165,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
         },
       })
 
-      const workExperiencePromise = getReport<any[]>({
+      const workExperiencePromise = getReport<EmployeeExperience[]>({
         accessToken: req.accessToken,
         reportName: 'workExperience',
         queryParams: {
@@ -168,7 +173,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
         },
       })
 
-      const employeeInformationPromise = getReport<any[]>({
+      const employeeInformationPromise = getReport<EmployeeInformation[]>({
         accessToken: req.accessToken,
         reportName: 'employeeInformation',
         queryParams: {
@@ -182,6 +187,8 @@ router.get<unknown, unknown, unknown, EmailParam>(
           workExperiencePromise,
           employeeInformationPromise,
         ])
+
+      // TODO: Should probably return 404/Not found if employeeInformation is empty?
 
       const aggregatedData = aggregateEmployeeProfile(
         employeeSkills,

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -24,20 +24,27 @@ export type Customer = {
   weight: number
 }
 
-export type EmployeeProfile = EmployeeWithMergedCustomers & {
+export type EmployeeProfile = Omit<
+  EmployeeWithMergedCustomers,
+  'customer' | 'weight' | 'work_order_description' | 'image_key' | 'link'
+> & {
   image: string
   workExperience: EmployeeExperience[]
-  tags: {
-    languages: string[]
-    skills: string[]
-    roles: string[]
-  }
-  links: {
-    no_pdf: string
-    int_pdf: string
-    no_word: string
-    int_word: string
-  }
+  tags: Tags
+  links: Links
+}
+
+type Tags = {
+  languages: string[]
+  skills: string[]
+  roles: string[]
+}
+
+type Links = {
+  no_pdf: string
+  int_pdf: string
+  no_word: string
+  int_word: string
 }
 
 export type EmployeeSkills = {

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -14,12 +14,32 @@ export type EmployeeInformation = {
   work_order_description?: string
 }
 
-export type MergeEmployees = EmployeeInformation & {
-  customerArray: {
-    customer: string
-    wordOrderDescription: string
-    weight: number
-  }[]
+export type EmployeeWithMergedCustomers = EmployeeInformation & {
+  customers: Customer[]
+}
+
+export type Customer = {
+  customer: string
+  workOrderDescription: string
+  weight: number
+}
+
+export type EmployeeProfile = {
+  employee: EmployeeWithMergedCustomers
+  image: string
+  workExperience: EmployeeExperience[]
+  tags: {
+    // TODO: verify that the tag types reflects what is actually extracted from the report
+    language: string // Semicolon-separated list (?)
+    skills: string // Semicolon-separated list (?)
+    role: string // Semicolon-separated list (?)
+  }
+  links: {
+    no_pdf: string
+    int_pdf: string
+    no_word: string
+    int_word: string
+  }
 }
 
 export type JobRotation = {

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -29,9 +29,19 @@ export type EmployeeProfile = Omit<
   'customer' | 'weight' | 'work_order_description' | 'image_key' | 'link'
 > & {
   image: string
-  workExperience: EmployeeExperience[]
+  workExperience: WorkExperience[]
   tags: Tags
   links: Links
+}
+
+export type WorkExperience = {
+  user_id: string
+  email: string
+  employer: string
+  month_from: number
+  month_to: number
+  year_from: number
+  year_to: number
 }
 
 type Tags = {

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -24,15 +24,13 @@ export type Customer = {
   weight: number
 }
 
-export type EmployeeProfile = {
-  employee: EmployeeWithMergedCustomers
+export type EmployeeProfile = EmployeeWithMergedCustomers & {
   image: string
   workExperience: EmployeeExperience[]
   tags: {
-    // TODO: verify that the tag types reflects what is actually extracted from the report
-    language: string // Semicolon-separated list (?)
-    skills: string // Semicolon-separated list (?)
-    role: string // Semicolon-separated list (?)
+    languages: string[]
+    skills: string[]
+    roles: string[]
   }
   links: {
     no_pdf: string
@@ -40,6 +38,14 @@ export type EmployeeProfile = {
     no_word: string
     int_word: string
   }
+}
+
+export type EmployeeSkills = {
+  user_id: string
+  email: string
+  language: string // Semi-colon separated list
+  skill: string // Semi-colon separated list
+  role: string // Semi-colon separated list
 }
 
 export type JobRotation = {

--- a/src/api/data/employee/employeeApi.ts
+++ b/src/api/data/employee/employeeApi.ts
@@ -1,7 +1,7 @@
 import { CompetenceAreasResponse } from '../competence/competenceApiTypes'
 import { getAtApi } from '../../client'
 import {
-  EmpDataResponse,
+  EmployeeProfileResponse,
   EmployeeExperienceResponse,
   EmployeeTableResponse,
 } from './employeeApiTypes'
@@ -21,10 +21,7 @@ export const getEmployeeRadar = (url: string, email: string) =>
     params: { email },
   })
 
-// ! This might not be typed correctly
-export const getEmpData = (url: string, email: string) =>
-  getAtApi<EmpDataResponse>('/data/empData', {
-    params: {
-      email,
-    },
+export const getEmployeeProfile = (url: string, email: string) =>
+  getAtApi<EmployeeProfileResponse>('/data/employeeProfile', {
+    params: { email },
   })

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -35,15 +35,13 @@ interface Tags {
  * EmployeeProfile
  */
 
-export interface EmployeeProfileResponse {
-  employee: Employee
+export interface EmployeeProfileResponse extends Employee {
   image?: string
   workExperience: WorkExperience[]
   tags: {
-    // TODO does not match `Tags` type above, and can be undefined from backend?
-    skill: string
-    role: string
-    language: string
+    skills: string[]
+    languages: string[]
+    roles: string[]
   }
   links: Links
 }

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -38,11 +38,7 @@ interface Tags {
 export interface EmployeeProfileResponse extends Employee {
   image?: string
   workExperience: WorkExperience[]
-  tags: {
-    skills: string[]
-    languages: string[]
-    roles: string[]
-  }
+  tags: Tags
   links: Links
 }
 
@@ -52,7 +48,6 @@ interface Employee {
   navn: string
   manager: string
   title: string
-  link: string
   degree?: string
   email: string
   customers: Customer[]
@@ -62,6 +57,12 @@ export interface Customer {
   customer: string
   workOrderDescription: string
   weight: number
+}
+
+interface Tags {
+  skills: string[]
+  languages: string[]
+  roles: string[]
 }
 
 interface Links {

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -8,6 +8,13 @@ export interface EmployeeTableResponse {
 
 // employeeExperience
 
+export interface EmployeeExperienceResponse {
+  workExperience: WorkExperience[]
+  tags: Tags
+  manager: string
+  guid: string
+}
+
 interface WorkExperience {
   user_id: string
   email: string
@@ -24,50 +31,44 @@ interface Tags {
   roles: string[]
 }
 
-export interface EmployeeExperienceResponse {
+/**
+ * EmployeeProfile
+ */
+
+export interface EmployeeProfileResponse {
+  employee: Employee
+  image?: string
   workExperience: WorkExperience[]
-  tags: Tags
-  manager: string
-  guid: string
+  tags: {
+    // TODO does not match `Tags` type above, and can be undefined from backend?
+    skill: string
+    role: string
+    language: string
+  }
+  links: Links
 }
 
-// empData
-
-export interface CustomerArray {
-  customer: string
-  workOrderDescription: string
-  weight: number
-}
-
-export interface Employee {
+interface Employee {
   user_id: string
   guid: string
   navn: string
   manager: string
   title: string
   link: string
-  degree: string
+  degree?: string
   email: string
-  customer: string
-  weight: number
-  work_order_description: string
-  customerArray: CustomerArray[]
+  customers: Customer[]
 }
 
-export interface Links {
+export interface Customer {
+  customer: string
+  workOrderDescription: string
+  weight: number
+}
+
+interface Links {
   no_pdf: string
   int_pdf: string
   no_word: string
   int_word: string
-}
-
-export interface EmpDataResponse {
-  email_id: string
-  user_id: string
-  employee: Employee
-  workExperience: WorkExperience[]
-  degree: string
-  manager: string
-  links: Links
-  customerArray: CustomerArray[]
 }

--- a/src/api/data/employee/employeeQueries.ts
+++ b/src/api/data/employee/employeeQueries.ts
@@ -1,6 +1,6 @@
 import useSWR from 'swr'
 import {
-  getEmpData,
+  getEmployeeProfile,
   getEmployeeExperience,
   getEmployeeRadar,
   getEmployeeTable,
@@ -16,12 +16,12 @@ export const useEmployeeExperience = (user_id: string) =>
     revalidateOnFocus: false,
   })
 
-export const useEmpData = (email: string) =>
-  useSWR(['/empData', email], getEmpData, {
+export const useEmployeeProfile = (email: string) =>
+  useSWR(['/employeeProfile', email], getEmployeeProfile, {
     revalidateOnFocus: false,
   })
 
 export const useEmployeeRadar = (email: string) =>
-  useSWR(['/empData', email], getEmployeeRadar, {
+  useSWR(['/employeeRadar', email], getEmployeeRadar, {
     revalidateOnFocus: false,
   })

--- a/src/components/Content.tsx
+++ b/src/components/Content.tsx
@@ -6,7 +6,7 @@ import {
   Competence,
   Customer,
   EmployeePage,
-  EmployeeSite,
+  EmployeeProfile,
   NotFound,
   UnderConstruction,
 } from '../pages'
@@ -28,7 +28,7 @@ export default function Content() {
       <Route path="/kompetanse" element={<Competence />} />
       <Route path="/arbeidsmiljo" element={<UnderConstruction />} />
       <Route path="/rekruttering" element={<UnderConstruction />} />
-      <Route path="/ansatt/:id" element={<EmployeeSite />} />
+      <Route path="/ansatt/:id" element={<EmployeeProfile />} />
       <Route path="/debug" element={<Debug />} />
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/components/EmployeeInfo.tsx
+++ b/src/components/EmployeeInfo.tsx
@@ -3,7 +3,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import { Skeleton } from '@material-ui/lab'
 import { useFetchedData } from '../hooks/service'
 import { NoData } from './ErrorText'
-import { ExperienceData, ProjectExperience } from '../pages/EmployeeSite'
+import { ExperienceData, ProjectExperience } from '../pages/EmployeeProfile'
 import Chart from '../data/components/chart/Chart'
 import { useEmployeeRadar } from '../api/data/employee/employeeQueries'
 

--- a/src/pages.ts
+++ b/src/pages.ts
@@ -2,7 +2,7 @@ import NotFound from './pages/NotFound'
 import UnderConstruction from './pages/UnderConstruction'
 import EmployeePage from './pages/EmployeePage'
 import Competence from './pages/Competence'
-import EmployeeSite from './pages/EmployeeSite'
+import EmployeeProfile from './pages/EmployeeProfile'
 import Customer from './pages/customer/Customer'
 
 export {
@@ -10,6 +10,6 @@ export {
   UnderConstruction,
   EmployeePage,
   Competence,
-  EmployeeSite,
+  EmployeeProfile,
   Customer,
 }

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -1,19 +1,19 @@
 import React, { useEffect, useState } from 'react'
 import { getTestV2 } from '../api/client'
-import { useEmpData } from '../api/data/employee/employeeQueries'
 import { GridItem } from '../components/GridItem'
 import { Grid } from '@material-ui/core'
+import { useEmployeeProfile } from '../api/data/employee/employeeQueries'
 
 const Debug = () => {
   const [data, setData] = useState<any>()
 
   // Old api may use hooks to fetch data
-  const { data: dt } = useEmpData('einar.halvorsen@knowit.no')
+  const { data: dt } = useEmployeeProfile('einar.halvorsen@knowit.no')
 
   // New api uses getTestV2 as of now to compare output
   useEffect(() => {
     const fetch = async () => {
-      const res = await getTestV2<any>('/employees/empData', {
+      const res = await getTestV2<any>('/employees/employeeProfile', {
         params: {
           email: 'einar.halvorsen@knowit.no',
         },

--- a/src/pages/EmployeeProfile.tsx
+++ b/src/pages/EmployeeProfile.tsx
@@ -72,7 +72,7 @@ export const ChartSkeleton = () => (
   <Skeleton variant="rect" height={320} width={400} animation="wave" />
 )
 
-export default function EmployeeSite() {
+export default function EmployeeProfile() {
   const location = useLocation()
   const email = location.pathname.split('/')[2]
   const idRegex = /^(\w+\.?)*@knowit.no$/

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -13,6 +13,7 @@ import {
 import { ReactComponent as FallbackUserIcon } from '../assets/fallback_user.svg'
 import { CustomerStatusData } from '../data/components/table/cells/CustomerStatusCell'
 import { useEmployeeRadar } from '../api/data/employee/employeeQueries'
+import { EmployeeProfileResponse } from '../api/data/employee/employeeApiTypes'
 
 type WorkExperience = {
   employer: string
@@ -20,12 +21,6 @@ type WorkExperience = {
   year_from: number
   month_to: number
   year_to: number
-}
-type EmpData = {
-  email: string
-  navn: string
-  title: string
-  user_id: string
 }
 
 export interface ProjectExperience {
@@ -38,29 +33,6 @@ export interface ProjectExperience {
 export interface ExperienceData {
   name: string
   experience: ProjectExperience[]
-}
-
-type EmpSiteData = {
-  email_id: string
-  user_id: string
-  employee: EmpData
-  image: string
-  tags: {
-    skill: string
-    role: string
-    language: string
-  }
-  workExperience: WorkExperience[]
-  degree: string
-  manager: string
-  guid: string
-  links: {
-    no_pdf: string
-    int_pdf: string
-    no_word: string
-    int_word: string
-  }
-  customerArray: CustomerStatusData[]
 }
 
 const useStyles = makeStyles({
@@ -117,7 +89,7 @@ export default function EmployeeSite() {
 
   const classes = useStyles()
 
-  const user_id = data ? data.user_id : null
+  const user_id = data ? data.employee.user_id : null
   const emp = data ? data.employee : null
   const tags = data ? data.tags : null
   const [expData, expPending] = useFetchedData<ExperienceData>({
@@ -238,7 +210,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Utdanning: </b>
-                  {data && data?.degree}
+                  {data && data.employee.degree}
                 </>
               )}
             </div>
@@ -253,7 +225,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Nærmeste leder: </b>
-                  {data && data?.manager}
+                  {data && data.employee.manager}
                 </>
               )}
             </div>
@@ -299,7 +271,7 @@ export default function EmployeeSite() {
         {pending ? (
           <p>loading....</p>
         ) : (
-          <PrintCustomers customerArray={data?.customerArray} />
+          <PrintCustomers customerArray={data?.employee.customers} />
         )}
         <h2>Arbeidserfaring</h2>
         {pending ? (

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -15,14 +15,6 @@ import { CustomerStatusData } from '../data/components/table/cells/CustomerStatu
 import { useEmployeeRadar } from '../api/data/employee/employeeQueries'
 import { EmployeeProfileResponse } from '../api/data/employee/employeeApiTypes'
 
-type WorkExperience = {
-  employer: string
-  month_from: number
-  year_from: number
-  month_to: number
-  year_to: number
-}
-
 export interface ProjectExperience {
   customer: string
   project: string
@@ -89,8 +81,8 @@ export default function EmployeeSite() {
 
   const classes = useStyles()
 
-  const user_id = data ? data.employee.user_id : null
-  const emp = data ? data.employee : null
+  const user_id = data ? data.user_id : null
+  const emp = data ?? null
   const tags = data ? data.tags : null
   const [expData, expPending] = useFetchedData<ExperienceData>({
     url: `/api/data/employeeExperience?user_id=${user_id}`,
@@ -135,7 +127,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Hovedkompetanse: </b>
-                  {tags?.skill.replace(/;/g, ', ')}
+                  {tags?.skills.join(', ')}
                 </>
               )}
             </div>
@@ -150,7 +142,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Roller: </b>
-                  {tags?.role.replace(/;/g, ', ')}
+                  {tags?.roles.join(', ')}
                 </>
               )}
             </div>
@@ -195,7 +187,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Språk: </b>
-                  {tags?.language.replace(/;/g, ', ')}
+                  {tags?.languages.join(', ')}
                 </>
               )}
             </div>
@@ -210,7 +202,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Utdanning: </b>
-                  {data && data.employee.degree}
+                  {data?.degree}
                 </>
               )}
             </div>
@@ -225,7 +217,7 @@ export default function EmployeeSite() {
               ) : (
                 <>
                   <b>Nærmeste leder: </b>
-                  {data && data.employee.manager}
+                  {data?.manager}
                 </>
               )}
             </div>
@@ -271,7 +263,7 @@ export default function EmployeeSite() {
         {pending ? (
           <p>loading....</p>
         ) : (
-          <PrintCustomers customerArray={data?.employee.customers} />
+          <PrintCustomers customerArray={data?.customers} />
         )}
         <h2>Arbeidserfaring</h2>
         {pending ? (

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -77,7 +77,7 @@ export default function EmployeeSite() {
   const email = location.pathname.split('/')[2]
   const idRegex = /^(\w+\.?)*@knowit.no$/
   const url = '/api/data/empData?email=' + email
-  const [data, pending] = useFetchedData<EmpSiteData>({ url })
+  const [data, pending] = useFetchedData<EmployeeProfileResponse>({ url })
 
   const classes = useStyles()
 

--- a/src/pages/EmployeeSite.tsx
+++ b/src/pages/EmployeeSite.tsx
@@ -76,7 +76,7 @@ export default function EmployeeSite() {
   const location = useLocation()
   const email = location.pathname.split('/')[2]
   const idRegex = /^(\w+\.?)*@knowit.no$/
-  const url = '/api/data/empData?email=' + email
+  const url = '/api/data/employeeProfile?email=' + email
   const [data, pending] = useFetchedData<EmployeeProfileResponse>({ url })
 
   const classes = useStyles()


### PR DESCRIPTION
These are suggested improvements to the `empData` endpoint, in relation to refactoring the `EmployeeSite.tsx` page:

* Harmonize the terms `empData` and `EmployeeSite` to `EmployeeProfile`.
* Improve the JSON returned from `empData` endpoint. It had some redundant fields, and I've flattened the JSON structure a bit. The aggregation is not changed much, but I've made it a bit more robust.
* General renaming of variables/functions to communicate more clearly what they do.

The changes made in `data.ts` and `util.ts` has also been transferred to the new API (v2) code.