### PR TITLE
`employeeProfile` endpoint issues

### DIFF
--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -1,6 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import {
-  EmployeeInformation,
+  mapEmployeeTags,
   findCustomerWithHighestWeight,
   getEventSet,
   getWeek,
@@ -244,6 +244,43 @@ export const employeeExperience = async ({ data }: EmpExperience) => {
   }
 }
 
+export type EmployeeInformation = {
+  user_id: string
+  guid: string
+  navn: string
+  manager: string
+  title: string
+  link: string
+  degree: string
+  image_key: string
+  email: string
+  customer: string
+  weight: number
+  work_order_description: string
+}
+
+export type EmployeeSkills = {
+  user_id: string
+  email: string
+  language: string
+  skill: string
+  role: string
+}
+
+type WorkExperience = {
+  user_id: string
+  email: string
+  employer: string
+  month_from: number
+  month_to: number
+  year_from: number
+  year_to: number
+}
+
+type EmployeeData = {
+  data: [EmployeeSkills[], WorkExperience[], EmployeeInformation[]]
+}
+
 export const employeeCompetenceReports = ({
   parameters: { email } = {},
 }: ReportParams) => [
@@ -260,51 +297,19 @@ export const employeeCompetenceReports = ({
     filter: { email },
   },
 ]
-type EmployeeSkills = {
-  user_id: string
-  email: string
-  language: string
-  skill: string
-  role: string
-}
-type WorkExperience = {
-  user_id: string
-  email: string
-  employer: string
-  month_from: number
-  month_to: number
-  year_from: number
-  year_to: number
-}
-
-type EmployeeData = {
-  data: [EmployeeSkills[], WorkExperience[], EmployeeInformation[]]
-}
-
 /**
  * Dette endepunktet henter mer data om ansatte. Arbeidserfaring, ferdigheter,
  * språk,  utdanning og roller fra CV-partner og nærmeste leder fra AD.
  * Brukes i EmployeeInfo.tsx (utvidet tabell).
  */
 export const employeeCompetence = async ({ data }: EmployeeData) => {
-  const [resSkills, resEmp, resComp] = data
-  const mergedRes = mergeCustomersForEmployees(resComp)
-
-  const mapTags = (skills: EmployeeSkills[]) => {
-    const mappedSkills =
-      skills && skills.length > 0 ? skills[0] : ({} as EmployeeSkills)
-    return {
-      languages: mappedSkills.language ? mappedSkills.language.split(';') : [],
-      skills: mappedSkills.skill ? mappedSkills.skill.split(';') : [],
-      roles: mappedSkills.role ? mappedSkills.role.split(';') : [],
-    }
-  }
+  const [employeeSkills, workExperience, employeeInformation] = data
 
   return {
-    workExperience: resEmp,
-    tags: mapTags(resSkills),
-    manager: mergedRes[0].manager,
-    guid: mergedRes[0].guid,
+    workExperience,
+    tags: mapEmployeeTags(employeeSkills[0]),
+    manager: employeeInformation[0].manager,
+    guid: employeeInformation[0].guid,
   }
 }
 
@@ -692,7 +697,6 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
   }
 
   const employee = mergeCustomersForEmployees(employeeInformation)[0]
-  const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
     user_id: employee.user_id,
@@ -705,11 +709,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
     image: getStorageUrl(employee.image_key),
     customers: employee.customers,
     workExperience,
-    tags: {
-      skills: skill?.split(';') ?? [],
-      languages: language?.split(';') ?? [],
-      roles: role?.split(';') ?? [],
-    },
+    tags: mapEmployeeTags(employeeSkills[0]),
     links: Object.fromEntries(
       cvs.map(([lang, format]) => [
         `${lang}_${format}`,

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid'
 import {
   EmployeeInformation,
+  findCustomerWithHighestWeight,
   getEventSet,
   getWeek,
   getYear,
@@ -174,15 +175,8 @@ export const employeeTable = async ({ data }: EmployeeTable) => {
         degree: employee.degree,
       },
       employee.title,
-
       findProjectStatusForEmployee(jobRotation, employeeStatus, employee.guid),
-      employee.customers.reduce((prevCustomer, thisCustomer) => {
-        if (thisCustomer.weight < prevCustomer.weight) {
-          return thisCustomer
-        } else {
-          return prevCustomer
-        }
-      }),
+      findCustomerWithHighestWeight(employee.customers),
       Object.fromEntries(
         cvs.map(([lang, format]) => [
           `${lang}_${format}`,

--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -9,6 +9,7 @@ import {
   statusColorCode,
   sum,
 } from './util'
+import Reporting from '../reporting'
 
 /**
  *
@@ -693,7 +694,7 @@ export const employeeProfile = async ({ data }: EmployeeData) => {
   const [employeeSkills, workExperience, employeeInformation] = data
 
   if (!employeeInformation || employeeInformation.length === 0) {
-    return
+    throw Reporting({ status: 404, message: 'No employee information found' })
   }
 
   const employee = mergeCustomersForEmployees(employeeInformation)[0]

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -23,11 +23,13 @@ export type EmployeeInformation = {
 }
 
 type EmployeeWithMergedCustomers = EmployeeInformation & {
-  customers: {
-    customer: string
-    wordOrderDescription: string
-    weight: number
-  }[]
+  customers: Customer[]
+}
+
+type Customer = {
+  customer: string
+  workOrderDescription: string
+  weight: number
 }
 
 export const getYear = (): number => {
@@ -82,6 +84,20 @@ export const mergeCustomersForEmployees = (
   })
 
   return Object.values(employeesWithMergedCustomers)
+}
+
+export function findCustomerWithHighestWeight(customers: Customer[]) {
+  if (!customers || customers.length === 0) {
+    return {}
+  }
+
+  return customers.reduce((prevCustomer, thisCustomer) => {
+    if (thisCustomer.weight < prevCustomer.weight) {
+      return thisCustomer
+    } else {
+      return prevCustomer
+    }
+  })
 }
 
 export const statusColorCode = (

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -1,3 +1,4 @@
+import { EmployeeInformation, EmployeeSkills } from './data'
 import AWS from 'aws-sdk'
 AWS.config.update({ region: 'eu-central-1' })
 
@@ -7,20 +8,6 @@ export const range = (x: number, y: number) =>
       while (x <= y) yield x++
     })()
   )
-export type EmployeeInformation = {
-  user_id: string
-  guid: string
-  navn: string
-  manager: string
-  title: string
-  link: string
-  degree: string
-  image_key: string
-  email: string
-  customer: string
-  weight: number
-  work_order_description: string
-}
 
 type EmployeeWithMergedCustomers = EmployeeInformation & {
   customers: Customer[]
@@ -98,6 +85,16 @@ export function findCustomerWithHighestWeight(customers: Customer[]) {
       return prevCustomer
     }
   })
+}
+
+export function mapEmployeeTags(employeeSkills?: EmployeeSkills) {
+  const { skill, language, role } = employeeSkills ?? {}
+
+  return {
+    skills: skill?.split(';') ?? [],
+    languages: language?.split(';') ?? [],
+    roles: role?.split(';') ?? [],
+  }
 }
 
 export const statusColorCode = (

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -62,19 +62,22 @@ export const mergeCustomersForEmployees = (
   const employeesWithMergedCustomers = {}
 
   employees.forEach((employee) => {
-    const thisCustomer = {
-      customer: employee.customer,
-      workOrderDescription: employee.work_order_description,
-      weight: employee.weight,
-    }
-
     const employeeToMerge =
       employeesWithMergedCustomers[employee.guid] ?? employee
     const customersForEmployee = employeeToMerge.customers ?? []
 
+    if (employee.customer) {
+      const thisCustomer = {
+        customer: employee.customer,
+        workOrderDescription: employee.work_order_description,
+        weight: employee.weight,
+      }
+      customersForEmployee.push(thisCustomer)
+    }
+
     employeesWithMergedCustomers[employee.guid] = {
       ...employeeToMerge,
-      customers: [thisCustomer, ...customersForEmployee],
+      customers: customersForEmployee,
     }
   })
 

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -3,9 +3,11 @@ import {
   Customer,
   EmployeeInformation,
   EmployeeMotivationAndCompetence,
+  EmployeeSkills,
   EmployeeWithMergedCustomers,
   JobRotation,
   JobRotationStatus,
+  Tags,
 } from './employeesTypes'
 
 export const cvs = [
@@ -69,6 +71,16 @@ export function findCustomerWithHighestWeight(customers: Customer[]) {
       return prevCustomer
     }
   })
+}
+
+export function mapEmployeeTags(employeeSkills?: EmployeeSkills): Tags {
+  const { skill, language, role } = employeeSkills ?? {}
+
+  return {
+    skills: skill?.split(';') ?? [],
+    languages: language?.split(';') ?? [],
+    roles: role?.split(';') ?? [],
+  }
 }
 
 export const findProjectStatusForEmployee = (

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -35,21 +35,25 @@ export const mergeCustomersForEmployees = (
   const employeesWithMergedCustomers = {}
 
   employees.forEach((employee) => {
-    const thisCustomer: Customer = {
-      customer: employee.customer,
-      workOrderDescription: employee.work_order_description,
-      weight: employee.weight,
-    }
-
     const employeeToMerge: EmployeeWithMergedCustomers =
       employeesWithMergedCustomers[employee.guid] ?? employee
     const customersForEmployee = employeeToMerge.customers ?? []
 
+    if (employee.customer) {
+      const thisCustomer = {
+        customer: employee.customer,
+        workOrderDescription: employee.work_order_description,
+        weight: employee.weight,
+      }
+      customersForEmployee.push(thisCustomer)
+    }
+
     employeesWithMergedCustomers[employee.guid] = {
       ...employeeToMerge,
-      customers: [thisCustomer, ...customersForEmployee],
+      customers: customersForEmployee,
     }
   })
+
   return Object.values(employeesWithMergedCustomers)
 }
 

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -57,6 +57,20 @@ export const mergeCustomersForEmployees = (
   return Object.values(employeesWithMergedCustomers)
 }
 
+export function findCustomerWithHighestWeight(customers: Customer[]) {
+  if (!customers || customers.length === 0) {
+    return {}
+  }
+
+  return customers.reduce((prevCustomer, thisCustomer) => {
+    if (thisCustomer.weight < prevCustomer.weight) {
+      return thisCustomer
+    } else {
+      return prevCustomer
+    }
+  })
+}
+
 export const findProjectStatusForEmployee = (
   jobRotationEmployees: JobRotation[],
   email: string

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -1,6 +1,7 @@
 import { v4 as uuid } from 'uuid'
 import {
   cvs,
+  findCustomerWithHighestWeight,
   findProjectStatusForEmployee,
   getCategoryScoresForEmployee,
   getStorageUrl,
@@ -38,13 +39,7 @@ export const aggregateEmployeeTable = (
       },
       employee.title,
       findProjectStatusForEmployee(jobRotationInformation, employee.email),
-      employee.customers.reduce((prevCustomer, thisCustomer) => {
-        if (thisCustomer.weight < prevCustomer.weight) {
-          return thisCustomer
-        } else {
-          return prevCustomer
-        }
-      }),
+      findCustomerWithHighestWeight(employee.customers),
       Object.fromEntries(
         cvs.map(([lang, format]) => [
           `${lang}_${format}`,

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid'
 import {
+  mapEmployeeTags,
   cvs,
   findCustomerWithHighestWeight,
   findProjectStatusForEmployee,
@@ -121,7 +122,6 @@ export const aggregateEmployeeProfile = (
   }
 
   const employee = mergeCustomersForEmployees(employeeInformation)[0]
-  const { skill, language, role } = employeeSkills[0] ?? {}
 
   return {
     user_id: employee.user_id,
@@ -134,11 +134,7 @@ export const aggregateEmployeeProfile = (
     image: getStorageUrl(employee.image_key),
     customers: employee.customers,
     workExperience,
-    tags: {
-      skills: skill?.split(';') ?? [],
-      languages: language?.split(';') ?? [],
-      roles: role?.split(';') ?? [],
-    },
+    tags: mapEmployeeTags(employeeSkills[0]),
     links: {
       no_pdf: makeCvLink('no', 'pdf', employee.link),
       int_pdf: makeCvLink('int', 'pdf', employee.link),

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -44,7 +44,7 @@ export type WorkExperience = {
   year_to: number
 }
 
-type Tags = {
+export type Tags = {
   languages: string[]
   skills: string[]
   roles: string[]

--- a/backend/routers/handler.ts
+++ b/backend/routers/handler.ts
@@ -2,6 +2,7 @@ import reports from '../dataplattform/lib'
 import * as aggregation from '../repository/data'
 import reporting from '../reporting'
 import { Request } from 'express'
+import Reporting from '../reporting'
 
 async function handler(req: Request) {
   // Request data
@@ -45,11 +46,15 @@ async function handler(req: Request) {
 
   // Run data aggregation for endpoint
   const result = await endpointHandler({ data, parameters }).catch(
-    (err: string) => {
-      throw reporting({
-        message: err,
-        external: false,
-      })
+    (err: string | typeof Reporting) => {
+      if (typeof err === 'string') {
+        throw reporting({
+          status: 500,
+          message: err,
+        })
+      } else {
+        throw err
+      }
     }
   )
 

--- a/src/pages/EmployeeProfile.tsx
+++ b/src/pages/EmployeeProfile.tsx
@@ -263,7 +263,7 @@ export default function EmployeeProfile() {
         {pending ? (
           <p>loading....</p>
         ) : (
-          <PrintCustomers customerArray={data?.customers} />
+          <PrintCustomers customers={data?.customers} />
         )}
         <h2>Arbeidserfaring</h2>
         {pending ? (
@@ -294,15 +294,14 @@ export default function EmployeeProfile() {
   )
 }
 
-const PrintCustomers = (data: { customerArray?: CustomerStatusData[] }) => {
-  if (!data.customerArray || !data.customerArray[0].customer)
-    return <div>-</div>
-  data.customerArray.sort(
+const PrintCustomers = (props: { customers?: CustomerStatusData[] }) => {
+  if (!props.customers || props.customers.length === 0) return <div>-</div>
+  props.customers.sort(
     (customerA, customerB) => customerA.weight - customerB.weight
   )
   return (
     <>
-      {data.customerArray.map((customer, index) => {
+      {props.customers.map((customer, index) => {
         return (
           <div key={index}>
             <b>{customer.customer}: </b>


### PR DESCRIPTION
This PR primarily fixes an issue for cases where an employee is not related to any customers. The aggregated result was an array with a single empty object. This is now changed so that the return value is an empty array.

In addition, v1 of the API now returns a 404 response for `employeeProfile` if an employee is not found. This will make the error handling easier on the frontend side while we wait for v2 of the API.

Also made a few related changes:
* Finding the customer with the highest weight for an employee is now extracted as a separate, more robust function.
* The mapping of "tags" is also extracted as a separate function.
* The aggregation for the `employeeCompetence` endpoint is simplified (while giving the same result).

The changes made to the API is also transferred to v2.