### PR TITLE
Include job title in search for employee table

### DIFF
--- a/src/components/filter/FilterUtil.tsx
+++ b/src/components/filter/FilterUtil.tsx
@@ -27,15 +27,35 @@ function searchRow(
   searchableColumns: SearchableColumn[],
   searchTerm: string
 ) {
-  return searchableColumns
-    .map((column) =>
-      column
-        .getSearchValue(row.rowData[column.columnIndex])
-        .toLowerCase()
-        .trim()
-        .includes(searchTerm.toLowerCase().trim())
+  const wordsInSearchTerm = searchTerm
+    .split(' ')
+    .map(normalizeWord)
+    .filter(Boolean)
+
+  const searchableColumnWords = searchableColumns
+    .flatMap((column) => {
+      const columnValue = column.getSearchValue(row.rowData[column.columnIndex])
+      if (typeof columnValue === 'string') {
+        return columnValue.split(' ').map(normalizeWord)
+      }
+      if (typeof columnValue === 'number') {
+        return String(columnValue)
+      }
+      return []
+    })
+    .filter(Boolean)
+
+  return wordsInSearchTerm.every((searchWord) =>
+    searchableColumnWords.reduce(
+      (foundWordMatch: boolean, columnWord) =>
+        foundWordMatch || columnWord.includes(searchWord),
+      false
     )
-    .reduce((a, b) => a || b, false)
+  )
+}
+
+function normalizeWord(word: string) {
+  return word.toLowerCase().trim()
 }
 
 function filterRow(

--- a/src/data/DDTable.tsx
+++ b/src/data/DDTable.tsx
@@ -5,7 +5,7 @@ import DataTable from './components/table/DataTable'
 import SearchInput from '../components/SearchInput'
 import FilterInput from '../components/filter/FilterInput'
 import RowCount from './components/RowCount'
-import { Columns, DDTableProps } from './types'
+import { Columns, DDTableProps, GetSearchValueFn } from './types'
 import { makeStyles } from '@material-ui/core/styles'
 import {
   filterNonCustomer,
@@ -16,7 +16,6 @@ import {
 } from '../components/filter/FilterUtil'
 import { SortOrder } from './components/table/cells/SortableHeaderCell'
 
-type GetSearchValueFn = (data: unknown) => string
 export interface SearchableColumn {
   columnIndex: number
   getSearchValue: GetSearchValueFn

--- a/src/data/types.tsx
+++ b/src/data/types.tsx
@@ -21,7 +21,6 @@ export type ChartVariant = {
 export type Columns = {
   title: string
   isExpandable?: boolean
-  searchable?: boolean
   checkBoxLabel?: string
   getSearchValue?: (props: any) => string
   renderCell?: (props: any) => JSX.Element

--- a/src/data/types.tsx
+++ b/src/data/types.tsx
@@ -22,12 +22,14 @@ export type Columns = {
   title: string
   isExpandable?: boolean
   checkBoxLabel?: string
-  getSearchValue?: (props: any) => string
+  getSearchValue?: GetSearchValueFn
   renderCell?: (props: any) => JSX.Element
   renderExpanded?: (props: any) => JSX.Element
   headerCell?: (props: any) => JSX.Element
   checkBoxChangeHandler?: (event: React.ChangeEvent<HTMLInputElement>) => void
 }
+
+export type GetSearchValueFn = (data: any) => string | number | undefined | null
 
 export interface DDComponentProps {
   payload: any

--- a/src/pages/customer/CustomerList.tsx
+++ b/src/pages/customer/CustomerList.tsx
@@ -20,7 +20,6 @@ import CustomerFilter from './CustomerFilter'
 const CustomerColumns = [
   {
     title: 'Konsulent',
-    searchable: true,
     isExpandable: true,
     getSearchValue: (consultant: { value: string }) => {
       return consultant.value
@@ -32,7 +31,6 @@ const CustomerColumns = [
   {
     title: 'Kunde',
     renderCell: CustomerStatusCell,
-    searchable: true,
     getSearchValue: (customer: CustomerStatusData) => {
       return `${customer.customer} ${customer.workOrderDescription}`
     },

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -33,7 +33,6 @@ export function EmployeeTable() {
               {
                 title: 'Konsulent',
                 isExpandable: true,
-                searchable: true,
                 getSearchValue: (consultant: { value: string }) => {
                   return consultant.value
                 },
@@ -53,7 +52,6 @@ export function EmployeeTable() {
               {
                 title: 'Kunde',
                 renderCell: CustomerStatusCell,
-                searchable: true,
                 getSearchValue: (customer: CustomerStatusData) => {
                   return customer.customer
                     ? `${customer.customer} ${customer.workOrderDescription}`

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -44,8 +44,8 @@ export function EmployeeTable() {
               {
                 title: 'Tittel',
                 headerCell: SortableHeaderCell,
-                getSearchValue: (jobTitle?: string | null) => {
-                  return jobTitle ?? ''
+                getSearchValue: (jobTitle: string | undefined | null) => {
+                  return jobTitle
                 },
               },
               { title: 'Prosjektstatus', renderCell: ProjectStatusCell },

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -45,6 +45,9 @@ export function EmployeeTable() {
               {
                 title: 'Tittel',
                 headerCell: SortableHeaderCell,
+                getSearchValue: (jobTitle?: string | null) => {
+                  return jobTitle ?? ''
+                },
               },
               { title: 'Prosjektstatus', renderCell: ProjectStatusCell },
               {


### PR DESCRIPTION
Fixes [#614 ](https://github.com/knowit/Dataplattform-issues/issues/614) + some improvements to search functionality.

* Added `getSearchValue` function for the job title column, thus including it in the search values. 
* Fixed the `GetSearchValueFn` type so that it reflects the uncertainty of the real world.
* Removed redundant `searchable` property from column type.

Also refactored the searching functionality:
* more robust for unknown values
* support for multi-word searches, across columns