### PR TITLE
Oppdater frontend API med hensyn på nye backend-endringer

### DIFF
--- a/backend/routers/competence/competenceAggregation.ts
+++ b/backend/routers/competence/competenceAggregation.ts
@@ -196,8 +196,7 @@ export const competenceMapping = (
   }
 
   Object.values(aggregate()).forEach((category) => {
-    result.Competence.data.push(category)
-    result.Motivation.data.push(category)
+    result.MotivationAndCompetence.data.push(category)
   })
 
   return result

--- a/backend/routers/competence/competenceChartConversion.ts
+++ b/backend/routers/competence/competenceChartConversion.ts
@@ -15,14 +15,14 @@ import {
   experienceMapping,
 } from './competenceAggregation'
 import {
-  CategoryAverage,
-  CompetenceAmount,
-  YearsWorkingDistributionCount,
   AgeDistribution,
   AgeGroupDistribution,
-  FagtimeStats,
-  FagEventData,
+  CategoryAverage,
+  CompetenceAmount,
   DegreeDistribution,
+  FagEventData,
+  FagtimeStats,
+  YearsWorkingDistributionCount,
 } from './competenceTypes'
 
 // /experienceDistribution
@@ -144,9 +144,7 @@ export const ageDistributionBar = (
   }
 }
 
-export const fagtimerLine = (
-  data: FagtimeStats[]
-): Record<string, LineChartData[]> => {
+export const fagtimerLine = (data: FagtimeStats[]): LineChartData[] => {
   const toLineData = (data: FagtimeStats[]): LineChartData[] => {
     const setData = range(2018, new Date().getFullYear()).map((year) => ({
       id: year.toString(),
@@ -167,25 +165,19 @@ export const fagtimerLine = (
     return setData
   }
 
-  return { FagTimer: toLineData(data) }
+  return toLineData(data)
 }
 
-export const fagEventsLine = (
-  data: FagEventData[]
-): Record<string, LineChartData[]> => {
+export const fagEventsLine = (data: FagEventData[]): LineChartData[] => {
   const aggregatedData = getEventSet(data)
-  return {
-    'Fag og hendelser': aggregatedData,
-  }
+  return aggregatedData
 }
 
-export const educationPie = (
-  data: DegreeDistribution[]
-): Record<string, PieChartData> => {
+export const educationPie = (data: DegreeDistribution[]): PieChartData => {
   const id = 'degree'
   const value = 'count'
 
-  return { Utdanning: { id, value, data } }
+  return { id, value, data }
 }
 
 export const competenceMappingBar = (data: CategoryAverage[]) => {
@@ -197,12 +189,12 @@ export const competenceMappingBar = (data: CategoryAverage[]) => {
     Competence: {
       indexBy,
       keys: ['competence'],
-      data: aggregatedData.Competence.data,
+      data: aggregatedData.MotivationAndCompetence.data,
     },
     Motivation: {
       indexBy,
       keys: ['motivation'],
-      data: aggregatedData.Motivation.data,
+      data: aggregatedData.MotivationAndCompetence.data,
     },
   }
 }

--- a/backend/routers/customer/customerRouter.ts
+++ b/backend/routers/customer/customerRouter.ts
@@ -43,4 +43,5 @@ router.get('/customerCards', async (req, res, next) => {
     next(error)
   }
 })
+
 export { router as customerRouter }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -65,6 +65,9 @@ const getAt = async <T>(endpoint: string, options?: GetOptions) => {
 export const getAtApi = <T>(endpoint: string, options?: GetOptions) =>
   getAt<T>(`/api${endpoint}`, options)
 
+export const getAtApiV2 = <T>(endpoint: string, options?: GetOptions) =>
+  getAt<T>(`/api/v2${endpoint}`, options)
+
 export const getAtAuth = <T>(endpoint: string, options?: GetOptions) =>
   getAt<T>(`/auth${endpoint}`, options)
 

--- a/src/api/data/chartResponses.ts
+++ b/src/api/data/chartResponses.ts
@@ -1,10 +1,10 @@
+export type MultipleChartResponse<T> = Record<string, T>
+
 export interface BarChartData {
   indexBy: string
   keys: string[]
   data: any[]
 }
-
-export type BarChartDataResponse = Record<string, BarChartData>
 
 export interface RadarChartData {
   indexBy: string
@@ -12,12 +12,22 @@ export interface RadarChartData {
   data: any[]
 }
 
-export type RadarChartDataResponse = Record<string, RadarChartData>
-
 export type LineChartData = {
   id: string | number
   data: Array<{
     x: number | string | Date
     y: number | string | Date
   }>
+}[]
+
+export interface PieChartData {
+  id: string
+  value: string
+  data: any[]
+}
+
+export interface SunburstChartData {
+  id: string
+  value: string
+  data: any[]
 }

--- a/src/api/data/chartResponses.ts
+++ b/src/api/data/chartResponses.ts
@@ -4,11 +4,15 @@ export interface BarChartData {
   data: any[]
 }
 
+export type BarChartDataResponse = Record<string, BarChartData>
+
 export interface RadarChartData {
   indexBy: string
   keys: string[]
   data: any[]
 }
+
+export type RadarChartDataResponse = Record<string, RadarChartData>
 
 export type LineChartData = {
   id: string | number

--- a/src/api/data/chartResponses.ts
+++ b/src/api/data/chartResponses.ts
@@ -1,0 +1,19 @@
+export interface BarChartData {
+  indexBy: string
+  keys: string[]
+  data: any[]
+}
+
+export interface RadarChartData {
+  indexBy: string
+  keys: string[]
+  data: any[]
+}
+
+export type LineChartData = {
+  id: string | number
+  data: Array<{
+    x: number | string | Date
+    y: number | string | Date
+  }>
+}

--- a/src/api/data/competence/competenceApi.ts
+++ b/src/api/data/competence/competenceApi.ts
@@ -1,4 +1,12 @@
-import { getAtApi } from '../../client'
+import { getAtApi, getAtApiV2 } from '../../client'
+import {
+  BarChartData,
+  LineChartData,
+  MultipleChartResponse,
+  PieChartData,
+  RadarChartData,
+  SunburstChartData,
+} from '../chartResponses'
 import {
   AgeDistributionResponse,
   CompetenceAmountResponse,
@@ -34,3 +42,53 @@ export const getCompetenceMapping = () =>
 
 export const getCompetenceFilter = () =>
   getAtApi<CompetenceFilterResponse[]>('/data/competenceFilter')
+
+// API V2
+export const getExperienceDistributionBar = () =>
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/competence/experienceDistribution/bar'
+  )
+
+export const getExperienceDistributionPie = () =>
+  getAtApiV2<MultipleChartResponse<PieChartData>>(
+    '/competence/experienceDistribution/pie'
+  )
+
+export const getCompetenceAmountBar = () =>
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/competence/competenceAmount/bar'
+  )
+
+export const getCompetenceAreasBar = () =>
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/competence/competenceAreas/bar'
+  )
+
+export const getCompetenceAreasRadar = () =>
+  getAtApiV2<MultipleChartResponse<RadarChartData>>(
+    '/competence/competenceAreas/radar'
+  )
+
+export const getAgeDistributionBar = () =>
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/competence/ageDistribution/bar'
+  )
+
+export const getFagtimerLine = () =>
+  getAtApiV2<LineChartData>('/competence/fagtimer/line')
+
+export const getFagEventsLine = () =>
+  getAtApiV2<LineChartData>('/competence/fagEvents/line')
+
+export const getEducationPie = () =>
+  getAtApiV2<PieChartData>('/competence/education/pie')
+
+export const getCompetenceMappingBar = () =>
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/competence/competenceMapping/bar'
+  )
+
+export const getCompetenceMappingSunburst = () =>
+  getAtApiV2<MultipleChartResponse<SunburstChartData>>(
+    '/competence/competenceMapping/sunburst'
+  )

--- a/src/api/data/competence/competenceQueries.ts
+++ b/src/api/data/competence/competenceQueries.ts
@@ -1,14 +1,25 @@
 import useSWR from 'swr'
 import {
   getAgeDistribution,
+  getAgeDistributionBar,
   getCompetenceAmount,
+  getCompetenceAmountBar,
   getCompetenceAreas,
+  getCompetenceAreasBar,
+  getCompetenceAreasRadar,
   getCompetenceFilter,
   getCompetenceMapping,
+  getCompetenceMappingBar,
+  getCompetenceMappingSunburst,
   getEducation,
+  getEducationPie,
   getExperienceDistribution,
+  getExperienceDistributionBar,
+  getExperienceDistributionPie,
   getFagEvents,
+  getFagEventsLine,
   getFagtimer,
+  getFagtimerLine,
 } from './competenceApi'
 
 // ? Maybe one can revalidate on focus? look at network and traffic
@@ -55,5 +66,61 @@ export const useCompetenceMapping = () =>
 
 export const useCompetenceFilter = () =>
   useSWR('/competenceFilter', getCompetenceFilter, {
+    revalidateOnFocus: false,
+  })
+
+// API v2
+export const useExperienceDistributionBar = () =>
+  useSWR('/experienceDistributionBar', getExperienceDistributionBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useExperienceDistributionPie = () =>
+  useSWR('/experienceDistributionPie', getExperienceDistributionPie, {
+    revalidateOnFocus: false,
+  })
+
+export const useCompetenceAmountBar = () =>
+  useSWR('/competenceAmountBar', getCompetenceAmountBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useCompetenceAreasBar = () =>
+  useSWR('/competenceAreasBar', getCompetenceAreasBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useCompetenceAreasRadar = () =>
+  useSWR('/competenceAreasRadar', getCompetenceAreasRadar, {
+    revalidateOnFocus: false,
+  })
+
+export const useAgeDistributionBar = () =>
+  useSWR('/ageDistributionBar', getAgeDistributionBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useFagtimerLine = () =>
+  useSWR('/fagtimerLine', getFagtimerLine, {
+    revalidateOnFocus: false,
+  })
+
+export const useFagEventsLine = () =>
+  useSWR('/fagEventsLine', getFagEventsLine, {
+    revalidateOnFocus: false,
+  })
+
+export const useEducationPie = () =>
+  useSWR('/educationPie', getEducationPie, {
+    revalidateOnFocus: false,
+  })
+
+export const useCompetenceMappingBar = () =>
+  useSWR('/competenceMappingBar', getCompetenceMappingBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useCompetenceMappingSunburst = () =>
+  useSWR('/competenceMappingSunburst', getCompetenceMappingSunburst, {
     revalidateOnFocus: false,
   })

--- a/src/api/data/customer/customerApi.ts
+++ b/src/api/data/customer/customerApi.ts
@@ -1,4 +1,4 @@
-import { getAtApi } from '../../client'
+import { getAtApi, getAtApiV2 } from '../../client'
 import { BarChartData, LineChartData } from '../chartResponses'
 import {
   CustomerCardResponse,
@@ -17,7 +17,7 @@ export const getHoursBilledPerWeek = () =>
 
 // API V2
 export const getHoursBilledPerCustomerBar = () =>
-  getAtApi<BarChartData>('/v2/customer/hoursBilledPerCustomer/bar')
+  getAtApiV2<BarChartData>('/customer/hoursBilledPerCustomer/bar')
 
 export const getHoursBilledPerWeekLine = () =>
-  getAtApi<LineChartData[]>('/v2/customer/hoursBilledPerWeek/line')
+  getAtApiV2<LineChartData>('/customer/hoursBilledPerWeek/line')

--- a/src/api/data/customer/customerApi.ts
+++ b/src/api/data/customer/customerApi.ts
@@ -1,4 +1,5 @@
 import { getAtApi } from '../../client'
+import { BarChartData, LineChartData } from '../chartResponses'
 import {
   CustomerCardResponse,
   HoursBilledPerCustomerResponse,
@@ -13,3 +14,10 @@ export const getHoursBilledPerCustomer = () =>
 
 export const getHoursBilledPerWeek = () =>
   getAtApi<HoursBilledPerWeekResponse>('/data/hoursBilledPerWeek')
+
+// API V2
+export const getHoursBilledPerCustomerBar = () =>
+  getAtApi<BarChartData>('/v2/customer/hoursBilledPerCustomer/bar')
+
+export const getHoursBilledPerWeekLine = () =>
+  getAtApi<LineChartData[]>('/v2/customer/hoursBilledPerWeek/line')

--- a/src/api/data/customer/customerQueries.ts
+++ b/src/api/data/customer/customerQueries.ts
@@ -2,7 +2,9 @@ import useSWR from 'swr'
 import {
   getCustomerCards,
   getHoursBilledPerCustomer,
+  getHoursBilledPerCustomerBar,
   getHoursBilledPerWeek,
+  getHoursBilledPerWeekLine,
 } from './customerApi'
 
 export const useCustomerCards = () =>
@@ -17,5 +19,16 @@ export const useHoursBilledPerCustomer = () =>
 
 export const useHoursBilledPerWeek = () =>
   useSWR('/hoursBilledPerWeek', getHoursBilledPerWeek, {
+    revalidateOnFocus: false,
+  })
+
+// API V2
+export const useHoursBilledPerCustomerBar = () =>
+  useSWR('/hoursBilledPerCustomerBar', getHoursBilledPerCustomerBar, {
+    revalidateOnFocus: false,
+  })
+
+export const useHoursBilledPerWeekLine = () =>
+  useSWR('/hoursBilledPerWeekLine', getHoursBilledPerWeekLine, {
     revalidateOnFocus: false,
   })

--- a/src/api/data/employee/employeeApi.ts
+++ b/src/api/data/employee/employeeApi.ts
@@ -1,5 +1,9 @@
-import { getAtApi } from '../../client'
-import { BarChartDataResponse, RadarChartDataResponse } from '../chartResponses'
+import { getAtApi, getAtApiV2 } from '../../client'
+import {
+  BarChartData,
+  MultipleChartResponse,
+  RadarChartData,
+} from '../chartResponses'
 import { CompetenceAreasResponse } from '../competence/competenceApiTypes'
 import {
   EmployeeExperienceResponse,
@@ -31,8 +35,8 @@ export const getEmployeeMotivationAndCompetenceBar = (
   url: string,
   email: string
 ) =>
-  getAtApi<BarChartDataResponse>(
-    '/v2/employees/employeeMotivationAndCompetence/bar',
+  getAtApiV2<MultipleChartResponse<BarChartData>>(
+    '/employees/employeeMotivationAndCompetence/bar',
     {
       params: { email },
     }
@@ -42,8 +46,8 @@ export const getEmployeeMotivationAndCompetenceRadar = (
   url: string,
   email: string
 ) =>
-  getAtApi<RadarChartDataResponse>(
-    '/v2/employees/employeeMotivationAndCompetence/radar',
+  getAtApiV2<MultipleChartResponse<RadarChartData>>(
+    '/employees/employeeMotivationAndCompetence/radar',
     {
       params: { email },
     }

--- a/src/api/data/employee/employeeApi.ts
+++ b/src/api/data/employee/employeeApi.ts
@@ -1,8 +1,9 @@
-import { CompetenceAreasResponse } from '../competence/competenceApiTypes'
 import { getAtApi } from '../../client'
+import { BarChartDataResponse, RadarChartDataResponse } from '../chartResponses'
+import { CompetenceAreasResponse } from '../competence/competenceApiTypes'
 import {
-  EmployeeProfileResponse,
   EmployeeExperienceResponse,
+  EmployeeProfileResponse,
   EmployeeTableResponse,
 } from './employeeApiTypes'
 
@@ -24,3 +25,26 @@ export const getEmployeeRadar = (url: string, email: string) =>
   getAtApi<CompetenceAreasResponse>(`/data/employeeRadar`, {
     params: { email },
   })
+
+// API V2
+export const getEmployeeMotivationAndCompetenceBar = (
+  url: string,
+  email: string
+) =>
+  getAtApi<BarChartDataResponse>(
+    '/v2/employees/employeeMotivationAndCompetence/bar',
+    {
+      params: { email },
+    }
+  )
+
+export const getEmployeeMotivationAndCompetenceRadar = (
+  url: string,
+  email: string
+) =>
+  getAtApi<RadarChartDataResponse>(
+    '/v2/employees/employeeMotivationAndCompetence/radar',
+    {
+      params: { email },
+    }
+  )

--- a/src/api/data/employee/employeeQueries.ts
+++ b/src/api/data/employee/employeeQueries.ts
@@ -4,6 +4,8 @@ import {
   getEmployeeExperience,
   getEmployeeRadar,
   getEmployeeTable,
+  getEmployeeMotivationAndCompetenceBar,
+  getEmployeeMotivationAndCompetenceRadar,
 } from './employeeApi'
 
 export const useEmployeeTable = () =>
@@ -35,3 +37,28 @@ export const useEmployeeRadar = (email?: string) =>
   useSWR(email ? ['/employeeRadar', email] : null, getEmployeeRadar, {
     revalidateOnFocus: false,
   })
+
+// API V2
+/**
+ * @param email Optional parameter, SWR waits until it is defined to fetch data
+ */
+export const useEmployeeMotivationAndCompetenceBar = (email?: string) =>
+  useSWR(
+    email ? ['/employeeMotivationAndCompetenceBar', email] : null,
+    getEmployeeMotivationAndCompetenceBar,
+    {
+      revalidateOnFocus: false,
+    }
+  )
+
+/**
+ * @param email Optional parameter, SWR waits until it is defined to fetch data
+ */
+export const useEmployeeMotivationAndCompetenceRadar = (email?: string) =>
+  useSWR(
+    email ? ['/employeeMotivationAndCompetenceRadar', email] : null,
+    getEmployeeMotivationAndCompetenceRadar,
+    {
+      revalidateOnFocus: false,
+    }
+  )

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -1,14 +1,14 @@
 import { Grid } from '@material-ui/core'
 import React, { useEffect, useState } from 'react'
 import { getTestV2 } from '../api/client'
-import { useHoursBilledPerWeek } from '../api/data/customer/customerQueries'
+import { useCompetenceMappingSunburst } from '../api/data/competence/competenceQueries'
 import { GridItem } from '../components/gridItem/GridItem'
 
 const Debug = () => {
   const [data, setData] = useState<any>()
 
   // Old api may use hooks to fetch data
-  const { data: dt } = useHoursBilledPerWeek()
+  const { data: dt } = useCompetenceMappingSunburst()
 
   // New api uses getTestV2 as of now to compare output
   useEffect(() => {


### PR DESCRIPTION
Oppdaterer `API` frontend til å reflektere endringene som har blitt gjort backend. Primært lages det enedpunkter/hooks for kall på chart-data som skal brukes i Nivo.

En del av API-urlene blir nå lange og stygge, men dette vil bli fikset når man er 100% på v2.

Så vidt jeg kan se nå, så er det nå klart for at frontenden kan skrives om til å bruke det nye APIet for fullt. 
På sikt kan mao alle SWR hooks og under-the-hood-getters som brukes for å opprettholde funksjonalitet, fjernes.

Extensive description here: [#557](https://github.com/knowit/Dataplattform-issues/issues/557).