### PR TITLE
Fix for filtering bug #570

### DIFF
--- a/src/components/filter/FilterHeader.tsx
+++ b/src/components/filter/FilterHeader.tsx
@@ -2,6 +2,7 @@ import { createStyles, makeStyles } from '@material-ui/core/styles'
 import React from 'react'
 import CloseIcon from '@material-ui/icons/Close'
 import { Mark, Slider } from '@material-ui/core'
+import { EmployeeTableColumnMapping } from './FilterUtil'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -115,7 +116,7 @@ interface Props {
   filterThreshold: number
   onThresholdUpdate: (value: number) => void
   onSkillClick: (value: string[]) => void
-  type: string
+  type: EmployeeTableColumnMapping
 }
 
 export function FilterHeader({
@@ -166,7 +167,7 @@ export function FilterHeader({
           />
         ))}
       </div>
-      {type != 'CUSTOMER' && (
+      {type != EmployeeTableColumnMapping.CUSTOMER ? (
         <div className={classes.filterThresholdContainer}>
           <label
             htmlFor={`${type}-threshold-slider`}
@@ -190,7 +191,7 @@ export function FilterHeader({
             onChange={handleThresholdSliderChange}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/src/components/filter/FilterUtil.tsx
+++ b/src/components/filter/FilterUtil.tsx
@@ -8,18 +8,19 @@ export interface CategoryWithGroup {
 }
 
 export interface FilterObject {
-  name: FilterType
+  name: DynamicFilterType
   values: string[]
   threshold: number
   placeholder: string
   datafetch: () => CategoryWithGroup[]
 }
-export type FilterType = 'COMPETENCE' | 'MOTIVATION' | 'CUSTOMER'
 
-const ColumnMapping: Record<FilterType, number> = {
-  MOTIVATION: 4,
-  COMPETENCE: 5,
-  CUSTOMER: 3,
+export type DynamicFilterType = 'COMPETENCE' | 'MOTIVATION'
+
+enum EmployeeTableColumnMapping {
+  CUSTOMER = 3,
+  MOTIVATION = 5,
+  COMPETENCE = 6,
 }
 
 function searchRow(
@@ -86,7 +87,7 @@ export const searchAndFilter = (
 
     filters.forEach((filter) => {
       if (filter.values.length > 0) {
-        const rowDataIndex = ColumnMapping[filter.name]
+        const rowDataIndex = EmployeeTableColumnMapping[filter.name]
         rowMatchesFilters =
           rowMatchesFilters &&
           filterRow(row.rowData[rowDataIndex], filter.values, filter.threshold)
@@ -99,7 +100,7 @@ export const searchAndFilter = (
 
 export function filterNonCustomer(rows: EmployeeTableResponse[]) {
   return rows.filter((row: EmployeeTableResponse) => {
-    const rowDataIndex = ColumnMapping['CUSTOMER']
+    const rowDataIndex = EmployeeTableColumnMapping['CUSTOMER']
     return Object.keys(row.rowData[rowDataIndex]).length === 0
   })
 }

--- a/src/components/filter/FilterUtil.tsx
+++ b/src/components/filter/FilterUtil.tsx
@@ -8,7 +8,7 @@ export interface CategoryWithGroup {
 }
 
 export interface FilterObject {
-  name: DynamicFilterType
+  column: EmployeeTableColumnMapping
   label: string
   values: string[]
   threshold: number
@@ -16,9 +16,7 @@ export interface FilterObject {
   datafetch: () => CategoryWithGroup[]
 }
 
-export type DynamicFilterType = 'COMPETENCE' | 'MOTIVATION'
-
-enum EmployeeTableColumnMapping {
+export enum EmployeeTableColumnMapping {
   CUSTOMER = 3,
   MOTIVATION = 5,
   COMPETENCE = 6,
@@ -88,10 +86,9 @@ export const searchAndFilter = (
 
     filters.forEach((filter) => {
       if (filter.values.length > 0) {
-        const rowDataIndex = EmployeeTableColumnMapping[filter.name]
         rowMatchesFilters =
           rowMatchesFilters &&
-          filterRow(row.rowData[rowDataIndex], filter.values, filter.threshold)
+          filterRow(row.rowData[filter.column], filter.values, filter.threshold)
       }
     })
 

--- a/src/components/filter/FilterUtil.tsx
+++ b/src/components/filter/FilterUtil.tsx
@@ -9,6 +9,7 @@ export interface CategoryWithGroup {
 
 export interface FilterObject {
   name: DynamicFilterType
+  label: string
   values: string[]
   threshold: number
   placeholder: string

--- a/src/data/DDTable.tsx
+++ b/src/data/DDTable.tsx
@@ -120,12 +120,12 @@ export default function DDTable({
   )
 
   const filterHeaders = filters.map(
-    ({ values, threshold, name, label }, index) =>
+    ({ values, threshold, column, label }, index) =>
       values.length > 0 && (
         <FilterHeader
-          key={name}
+          key={column}
           title={label}
-          type={name}
+          type={column}
           filterList={values}
           filterThreshold={threshold}
           onThresholdUpdate={(value) => {

--- a/src/data/DDTable.tsx
+++ b/src/data/DDTable.tsx
@@ -120,10 +120,11 @@ export default function DDTable({
   )
 
   const filterHeaders = filters.map(
-    ({ values, threshold, name }, index) =>
+    ({ values, threshold, name, label }, index) =>
       values.length > 0 && (
         <FilterHeader
-          title={name}
+          key={name}
+          title={label}
           type={name}
           filterList={values}
           filterThreshold={threshold}

--- a/src/data/components/table/DataTable.tsx
+++ b/src/data/components/table/DataTable.tsx
@@ -116,9 +116,9 @@ function VirtualizedTable({
   useEffect(() => {
     // We need to alert the react-virtualized table that the height of a
     // row has changed, so that it can recalculate total height and reposition
-    // rows. This runs when a row is expanded/collapsed:
+    // rows. This runs when a row is expanded/collapsed or when the sort order is changed:
     tableRef.current?.recomputeRowHeights()
-  }, [tableRef, expandedRowIds])
+  }, [tableRef, expandedRowIds, currentColumnSort])
 
   function rowIsExpanded(rowId: string) {
     return expandedRowIds.includes(rowId)

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -65,6 +65,7 @@ export function EmployeeTable() {
           initialFilters={[
             {
               name: 'COMPETENCE',
+              label: 'Kompetanse',
               values: [],
               threshold: 3,
               placeholder: 'Filtrer på kompetanse...',
@@ -72,6 +73,7 @@ export function EmployeeTable() {
             },
             {
               name: 'MOTIVATION',
+              label: 'Motivasjon',
               values: [],
               threshold: 4,
               placeholder: 'Filtrer på motivasjon...',

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -12,7 +12,10 @@ import EmployeeInfo from './EmployeeInfo'
 import { CustomerStatusData } from '../../../data/components/table/cells/CustomerStatusCell'
 import { Skeleton } from '@material-ui/lab'
 import { useEmployeeTable } from '../../../api/data/employee/employeeQueries'
-import { useCategories } from '../../../components/filter/FilterUtil'
+import {
+  EmployeeTableColumnMapping,
+  useCategories,
+} from '../../../components/filter/FilterUtil'
 import { GridItem } from '../../../components/gridItem/GridItem'
 
 export function EmployeeTable() {
@@ -64,16 +67,16 @@ export function EmployeeTable() {
           }}
           initialFilters={[
             {
-              name: 'COMPETENCE',
               label: 'Kompetanse',
+              column: EmployeeTableColumnMapping.COMPETENCE,
               values: [],
               threshold: 3,
               placeholder: 'Filtrer på kompetanse...',
               datafetch: useCategories,
             },
             {
-              name: 'MOTIVATION',
               label: 'Motivasjon',
+              column: EmployeeTableColumnMapping.MOTIVATION,
               values: [],
               threshold: 4,
               placeholder: 'Filtrer på motivasjon...',


### PR DESCRIPTION
Fixes [#570](https://github.com/knowit/Dataplattform-issues/issues/570) where the filters in the employee table did not work correctly because the index used when mapping competence and motivation columns was off by one. Converted the mapping type to an enum for better/simpler type safety.

Also made a couple of minor improvements to the employee table:
* added display labels for the filters (shown when a filter is active)
* fixed a problem where the table would not render correctly if the user sorted the table while a row was expanded