### PR TITLE
Improvements to customer list

### DIFF
--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -310,6 +310,7 @@ export const employeeCompetence = async ({ data }: EmployeeData) => {
     workExperience,
     tags: mapEmployeeTags(employeeSkills[0]),
     manager: employeeInformation[0].manager,
+    degree: employeeInformation[0].degree,
     guid: employeeInformation[0].guid,
   }
 }

--- a/backend/repository/reports.js
+++ b/backend/repository/reports.js
@@ -16,6 +16,20 @@ const reports = [
     lastCacheUpdate: '2022-01-21T11:50:08.289427',
   },
   {
+    name: 'employeesWithPrimaryCustomer',
+    queryString:
+      'WITH primary_customer AS (SELECT guid, work_order_description, CASE WHEN customer = "dagens ubw prosjekt" THEN kunde ELSE customer END AS customer_name FROM (SELECT * FROM dev_level_3_database.ubw_customer_per_resource LEFT JOIN (SELECT DISTINCT "dagens ubw prosjekt", arbeids_ordre, kunde FROM dev_level_3_database.test_test_no_kundemapping_test) ON "dagens ubw prosjekt" = customer AND arbeids_ordre = work_order_description) WHERE weigth = 1) SELECT cvpartner.user_id, cvpartner.guid, navn, title, link, email, image_key, primary_customer.customer_name, primary_customer.work_order_description FROM dev_level_3_database.cv_partner_employees AS cvpartner INNER JOIN primary_customer ON cvpartner.guid = primary_customer.guid ORDER BY navn',
+    tables: [
+      'cv_partner_employees',
+      'test_test_no_kundemapping_test',
+      'ubw_customer_per_resource',
+    ],
+    dataProtection: 3,
+    created: '2022-03-07T11:06:31.072355',
+    lastUsed: null,
+    lastCacheUpdate: '2022-03-07T11:06:36.536322',
+  },
+  {
     name: 'competence',
     queryString:
       'WITH last_education AS (SELECT a.user_id, array_agg(a.degree)[1] AS degree, array_agg(a.year_to)[1] AS year_to FROM dev_level_3_database.cv_partner_education a INNER JOIN (SELECT user_id, max(year_to) AS year_to FROM dev_level_3_database.cv_partner_education GROUP BY  user_id ) b ON a.user_id = b.user_id AND a.year_to = b.year_to GROUP BY  a.user_id) SELECT emp.user_id, navn, title, link, degree, email, image_key\n FROM dev_level_3_database.cv_partner_employees AS emp LEFT OUTER JOIN last_education AS e ON e.user_id = emp.user_id order by navn',

--- a/backend/routers/customer/customerAggregation.ts
+++ b/backend/routers/customer/customerAggregation.ts
@@ -1,0 +1,46 @@
+import { getStorageUrl, createCvLinks } from '../employees/aggregationHelpers'
+import {
+  EmployeeForCustomerList,
+  CustomerWithEmployees,
+  EmployeeWithPrimaryCustomer,
+} from './customerTypes'
+
+export function groupEmployeesByCustomer(
+  employeesWithPrimaryCustomer: EmployeeWithPrimaryCustomer[]
+): CustomerWithEmployees[] {
+  const customersWithEmployees: Record<string, EmployeeForCustomerList[]> = {}
+
+  employeesWithPrimaryCustomer.forEach((employee) => {
+    const { customer_name } = employee
+    if (!customersWithEmployees[customer_name]) {
+      customersWithEmployees[customer_name] = []
+    }
+    const employeeRow = createEmployeeForCustomerList(employee)
+    customersWithEmployees[customer_name].push(employeeRow)
+  })
+
+  return Object.entries(customersWithEmployees).map(
+    ([customerName, employees]) => ({
+      customer_name: customerName,
+      employees,
+    })
+  )
+}
+
+function createEmployeeForCustomerList(
+  employee: EmployeeWithPrimaryCustomer
+): EmployeeForCustomerList {
+  return {
+    rowId: employee.email,
+    rowData: [
+      {
+        name: employee.navn,
+        email: employee.email,
+        image_url: getStorageUrl(employee.image_key),
+      },
+      employee.title,
+      `${employee.customer_name}: ${employee.work_order_description}`,
+      createCvLinks(employee.link),
+    ],
+  }
+}

--- a/backend/routers/customer/customerAggregation.ts
+++ b/backend/routers/customer/customerAggregation.ts
@@ -34,9 +34,10 @@ function createEmployeeForCustomerList(
     rowId: employee.email,
     rowData: [
       {
-        name: employee.navn,
+        value: employee.navn,
         email: employee.email,
-        image_url: getStorageUrl(employee.image_key),
+        image: getStorageUrl(employee.image_key),
+        user_id: employee.user_id,
       },
       employee.title,
       `${employee.customer_name}: ${employee.work_order_description}`,

--- a/backend/routers/customer/customerRouter.ts
+++ b/backend/routers/customer/customerRouter.ts
@@ -8,6 +8,7 @@ import {
   BilledCustomerHours,
   EmployeeWithPrimaryCustomer,
 } from './customerTypes'
+import { groupEmployeesByCustomer } from './customerAggregation'
 
 const router = express.Router()
 
@@ -54,7 +55,8 @@ router.get('/employeesByCustomer', async (req, res, next) => {
       reportName: 'employeesWithPrimaryCustomer',
     })
 
-    res.send(data)
+    const aggregatedData = groupEmployeesByCustomer(data)
+    res.send(aggregatedData)
   } catch (error) {
     next(error)
   }

--- a/backend/routers/customer/customerRouter.ts
+++ b/backend/routers/customer/customerRouter.ts
@@ -4,7 +4,10 @@ import {
   hoursBilledPerCustomerBar,
   hoursBilledPerWeekLine,
 } from './customerChartConversion'
-import { BilledCustomerHours } from './customerTypes'
+import {
+  BilledCustomerHours,
+  EmployeeWithPrimaryCustomer,
+} from './customerTypes'
 
 const router = express.Router()
 
@@ -39,6 +42,19 @@ router.get('/hoursBilledPerWeek/line', async (req, res, next) => {
 router.get('/customerCards', async (req, res, next) => {
   try {
     res.send('Customer cards')
+  } catch (error) {
+    next(error)
+  }
+})
+
+router.get('/employeesByCustomer', async (req, res, next) => {
+  try {
+    const data = await getReport<EmployeeWithPrimaryCustomer[]>({
+      accessToken: req.accessToken,
+      reportName: 'employeesWithPrimaryCustomer',
+    })
+
+    res.send(data)
   } catch (error) {
     next(error)
   }

--- a/backend/routers/customer/customerTypes.ts
+++ b/backend/routers/customer/customerTypes.ts
@@ -1,3 +1,5 @@
+import { CvLinks } from '../employees/employeesTypes'
+
 export interface BilledCustomerHours {
   customer: string
   employees: number
@@ -16,4 +18,23 @@ export interface EmployeeWithPrimaryCustomer {
   image_key?: string
   customer_name: string
   work_order_description: string
+}
+
+export interface CustomerWithEmployees {
+  customer_name: string
+  employees: EmployeeForCustomerList[]
+}
+
+export type EmployeeForCustomerList = {
+  rowId: string
+  rowData: [
+    info: {
+      name: string
+      email: string
+      image_url: string | undefined
+    },
+    jobTitle: string | undefined,
+    customerAndProject: string,
+    cvLinks: CvLinks
+  ]
 }

--- a/backend/routers/customer/customerTypes.ts
+++ b/backend/routers/customer/customerTypes.ts
@@ -5,3 +5,15 @@ export interface BilledCustomerHours {
   reg_period: number
   timestamp: number
 }
+
+export interface EmployeeWithPrimaryCustomer {
+  user_id: string
+  guid: string
+  navn: string
+  title?: string
+  link: string
+  email: string
+  image_key?: string
+  customer_name: string
+  work_order_description: string
+}

--- a/backend/routers/customer/customerTypes.ts
+++ b/backend/routers/customer/customerTypes.ts
@@ -29,9 +29,10 @@ export type EmployeeForCustomerList = {
   rowId: string
   rowData: [
     info: {
-      name: string
       email: string
-      image_url: string | undefined
+      value: string // Employee name
+      image?: string
+      user_id: string
     },
     jobTitle: string | undefined,
     customerAndProject: string,

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -1,6 +1,7 @@
 import {
   CategoryScores,
   Customer,
+  CvLinks,
   EmployeeInformation,
   EmployeeMotivationAndCompetence,
   EmployeeSkills,
@@ -9,13 +10,6 @@ import {
   JobRotationStatus,
   Tags,
 } from './employeesTypes'
-
-export const cvs = [
-  ['no', 'pdf'],
-  ['int', 'pdf'],
-  ['no', 'word'],
-  ['int', 'word'],
-]
 
 export const getStorageUrl = (key: string) => {
   if (key !== undefined) {
@@ -146,10 +140,19 @@ export const getCategoryScoresForEmployee = (
   return [employeeMotivation, employeeCompetence]
 }
 
-export const makeCvLink = (
-  lang: string,
-  format: string,
-  linkTemplate?: string
-) => {
-  return linkTemplate?.replace('{LANG}', lang).replace('{FORMAT}', format)
+export function createCvLinks(linkTemplate: string): CvLinks {
+  if (!linkTemplate) {
+    // Just to be safe, should not happen
+    return
+  }
+  return {
+    no_pdf: createCvLink('no', 'pdf', linkTemplate),
+    int_pdf: createCvLink('int', 'pdf', linkTemplate),
+    no_word: createCvLink('no', 'word', linkTemplate),
+    int_word: createCvLink('int', 'word', linkTemplate),
+  }
+}
+
+function createCvLink(language: string, format: string, linkTemplate: string) {
+  return linkTemplate.replace('{LANG}', language).replace('{FORMAT}', format)
 }

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -1,13 +1,12 @@
 import { v4 as uuid } from 'uuid'
 import {
   mapEmployeeTags,
-  cvs,
   findCustomerWithHighestWeight,
   findProjectStatusForEmployee,
   getCategoryScoresForEmployee,
   getStorageUrl,
-  makeCvLink,
   mergeCustomersForEmployees,
+  createCvLinks,
 } from './aggregationHelpers'
 import {
   EmployeeExperience,
@@ -42,12 +41,7 @@ export const aggregateEmployeeTable = (
       employee.title,
       findProjectStatusForEmployee(jobRotationInformation, employee.email),
       findCustomerWithHighestWeight(employee.customers),
-      Object.fromEntries(
-        cvs.map(([lang, format]) => [
-          `${lang}_${format}`,
-          employee.link.replace('{LANG}', lang).replace('{FORMAT}', format),
-        ])
-      ),
+      createCvLinks(employee.link),
       getCategoryScoresForEmployee(
         employee.email,
         employeeMotivationAndCompetence
@@ -141,11 +135,6 @@ export const aggregateEmployeeProfile = (
     customers: employee.customers,
     workExperience,
     tags: mapEmployeeTags(employeeSkills[0]),
-    links: {
-      no_pdf: makeCvLink('no', 'pdf', employee.link),
-      int_pdf: makeCvLink('int', 'pdf', employee.link),
-      no_word: makeCvLink('no', 'word', employee.link),
-      int_word: makeCvLink('int', 'word', employee.link),
-    },
+    links: createCvLinks(employee.link),
   }
 }

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -31,7 +31,7 @@ export type EmployeeProfile = Omit<
   image: string
   workExperience: WorkExperience[]
   tags: Tags
-  links: Links
+  links: CvLinks
 }
 
 export type WorkExperience = {
@@ -50,7 +50,7 @@ export type Tags = {
   roles: string[]
 }
 
-type Links = {
+export type CvLinks = {
   no_pdf: string
   int_pdf: string
   no_word: string

--- a/src/api/data/customer/customerApi.ts
+++ b/src/api/data/customer/customerApi.ts
@@ -2,12 +2,16 @@ import { getAtApi, getAtApiV2 } from '../../client'
 import { BarChartData, LineChartData } from '../chartResponses'
 import {
   CustomerCardResponse,
+  EmployeesByCustomerResponse,
   HoursBilledPerCustomerResponse,
   HoursBilledPerWeekResponse,
 } from './customerApiTypes'
 
 export const getCustomerCards = () =>
   getAtApi<CustomerCardResponse>('/data/customerCards')
+
+export const getEmployeesByCustomer = () =>
+  getAtApiV2<EmployeesByCustomerResponse>('/customer/employeesByCustomer')
 
 export const getHoursBilledPerCustomer = () =>
   getAtApi<HoursBilledPerCustomerResponse>('/data/hoursBilledPerCustomer')

--- a/src/api/data/customer/customerApiTypes.ts
+++ b/src/api/data/customer/customerApiTypes.ts
@@ -23,8 +23,9 @@ export type EmployeeForCustomerList = {
   rowData: [
     info: {
       email: string
-      name: string
-      image_url?: string
+      value: string // Employee name
+      image?: string
+      user_id: string
     },
     jobTitle: string | null,
     customerAndProject: string,

--- a/src/api/data/customer/customerApiTypes.ts
+++ b/src/api/data/customer/customerApiTypes.ts
@@ -1,3 +1,5 @@
+import { CvLinks } from '../employee/employeeApiTypes'
+
 // customerCards
 interface CustomerCardData {
   customer: string
@@ -7,6 +9,28 @@ interface CustomerCardData {
 }
 
 export type CustomerCardResponse = CustomerCardData[]
+
+// employeesByCustomer (for CustomerList)
+export type EmployeesByCustomerResponse = CustomerWithEmployees[]
+
+export interface CustomerWithEmployees {
+  customer_name: string
+  employees: EmployeeForCustomerList[]
+}
+
+export type EmployeeForCustomerList = {
+  rowId: string
+  rowData: [
+    info: {
+      email: string
+      name: string
+      image_url?: string
+    },
+    jobTitle: string | null,
+    customerAndProject: string,
+    cvLinks: CvLinks
+  ]
+}
 
 // hoursBilledPerCustomer
 interface BilledCustomer {

--- a/src/api/data/customer/customerQueries.ts
+++ b/src/api/data/customer/customerQueries.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr'
 import {
   getCustomerCards,
+  getEmployeesByCustomer,
   getHoursBilledPerCustomer,
   getHoursBilledPerCustomerBar,
   getHoursBilledPerWeek,
@@ -9,6 +10,11 @@ import {
 
 export const useCustomerCards = () =>
   useSWR('/customerCard', getCustomerCards, {
+    revalidateOnFocus: false,
+  })
+
+export const useEmployeesByCustomer = () =>
+  useSWR('/employeesByCustomer', getEmployeesByCustomer, {
     revalidateOnFocus: false,
   })
 

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -42,7 +42,7 @@ export interface EmployeeProfileResponse extends Employee {
   image?: string
   workExperience: WorkExperience[]
   tags: Tags
-  links: Links
+  links: CvLinks
 }
 
 export interface Customer {
@@ -67,7 +67,7 @@ export interface Tags {
   roles: string[]
 }
 
-export interface Links {
+export interface CvLinks {
   no_pdf: string
   int_pdf: string
   no_word: string

--- a/src/components/filter/FilterUtil.tsx
+++ b/src/components/filter/FilterUtil.tsx
@@ -22,7 +22,7 @@ const ColumnMapping: Record<FilterType, number> = {
   CUSTOMER: 3,
 }
 
-function searchRow(
+export function searchRow(
   row: EmployeeTableResponse,
   searchableColumns: SearchableColumn[],
   searchTerm: string

--- a/src/components/gridItem/GridItem.tsx
+++ b/src/components/gridItem/GridItem.tsx
@@ -1,55 +1,14 @@
 import React from 'react'
 import { Grid } from '@material-ui/core'
-import { createStyles, makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 
-const useStyles = makeStyles(() =>
-  createStyles({
-    gridRoot: {
-      boxShadow: '0px 4px 10px #00000012',
-      borderRadius: '0px 0px 6px 6px',
-      overflow: 'hidden',
-    },
-    gridHeaderRoot: {
-      height: '65px',
-      backgroundColor: '#E4E1DB',
-      paddingLeft: '15px',
-      paddingRight: '15px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-    },
-    bigGridHeaderRoot: {
-      height: '102.7px',
-    },
-    gridHeaderTitle: {
-      fontSize: '18px',
-      fontWeight: 'normal',
-    },
-    BigGridHeaderTitle: {
-      fontSize: '30px',
-      fontWeight: 'normal',
-      paddingLeft: '11px',
-    },
-    gridContentRoot: {
-      width: '100%',
-      padding: '15px',
-      backgroundColor: 'white',
-      borderLeft: '1px solid #E4E1DB',
-      borderBottom: '1px solid #E4E1DB',
-      borderRight: '1px solid #E4E1DB',
-      borderRadius: '0px 0px 6px 6px',
-    },
-    knowitGreen: {
-      backgroundColor: '#00897B',
-      width: '100%',
-      height: '70px',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      margin: '0px',
-    },
-  })
-)
+const useStyles = makeStyles({
+  root: {
+    boxShadow: '0px 4px 10px #00000012',
+    borderRadius: '0px 0px 6px 6px',
+    overflow: 'hidden',
+  },
+})
 
 interface GridItemProps {
   fullSize?: boolean
@@ -61,7 +20,7 @@ export function GridItem({ children, fullSize = false }: GridItemProps) {
 
   return (
     <Grid item xs={fullSize ? 12 : 6}>
-      <div className={classes.gridRoot}>{children}</div>
+      <div className={classes.root}>{children}</div>
     </Grid>
   )
 }

--- a/src/components/gridItem/GridItemHeader.tsx
+++ b/src/components/gridItem/GridItemHeader.tsx
@@ -21,19 +21,24 @@ const useStyles = makeStyles(() =>
       fontSize: '18px',
       fontWeight: 'normal',
     },
-    BigGridHeaderTitle: {
+    bigGridHeaderTitle: {
       fontSize: '30px',
       fontWeight: 'normal',
       paddingLeft: '11px',
     },
     knowitGreen: {
       backgroundColor: '#00897B',
+      color: '#FFFFFF',
       width: '100%',
       height: '70px',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
       margin: '0px',
+    },
+    knowitGreenTitle: {
+      color: '#FFFFFF',
+      fontWeight: 'bold',
     },
   })
 )
@@ -55,15 +60,20 @@ export function GridItemHeader({
 }: GridItemHeaderProps) {
   const classes = useStyles()
   const headerHeight = big ? classes.bigGridHeaderRoot : null
-  const fontSize = big ? classes.BigGridHeaderTitle : null
+  const fontSize = big ? classes.bigGridHeaderTitle : null
   const knowitGreen = green ? classes.knowitGreen : null
+  const knowitGreenTitle = green ? classes.knowitGreenTitle : null
 
   return (
     <div
       className={[classes.gridHeaderRoot, headerHeight, knowitGreen].join(' ')}
     >
       <Grid container direction="row" alignItems="center">
-        <h3 className={[classes.gridHeaderTitle, fontSize].join(' ')}>
+        <h3
+          className={[classes.gridHeaderTitle, fontSize, knowitGreenTitle].join(
+            ' '
+          )}
+        >
           {title}
         </h3>
         {description ? (

--- a/src/data/DDTable.tsx
+++ b/src/data/DDTable.tsx
@@ -5,7 +5,7 @@ import DataTable from './components/table/DataTable'
 import SearchInput from '../components/SearchInput'
 import FilterInput from '../components/filter/FilterInput'
 import RowCount from './components/RowCount'
-import { Columns, DDTableProps, GetSearchValueFn } from './types'
+import { Column, DDTableProps, GetSearchValueFn } from './types'
 import { makeStyles } from '@material-ui/core/styles'
 import {
   filterNonCustomer,
@@ -55,7 +55,7 @@ const sortColumn = (rows: any[], currentSort: ColumnSort) => {
   }
 }
 
-export function getSearchableColumns(columns: Columns[]): SearchableColumn[] {
+export function getSearchableColumns(columns: Column[]): SearchableColumn[] {
   const result: SearchableColumn[] = []
   columns.forEach((column, index) => {
     if (column.getSearchValue) {

--- a/src/data/DDTable.tsx
+++ b/src/data/DDTable.tsx
@@ -4,7 +4,7 @@ import { FilterHeader } from '../components/filter/FilterHeader'
 import DataTable from './components/table/DataTable'
 import SearchInput from '../components/SearchInput'
 import FilterInput from '../components/filter/FilterInput'
-import RowCount from './components/RowCount'
+import { RowCount } from './components/RowCount'
 import { Column, DDTableProps, GetSearchValueFn } from './types'
 import { makeStyles } from '@material-ui/core/styles'
 import {
@@ -157,7 +157,7 @@ export default function DDTable({
       </GridItemHeader>
       {filterHeaders}
       <RowCount>
-        {sortedRows.length} av {allRows.length}
+        Viser {sortedRows.length} av {allRows.length} ansatte
       </RowCount>
       <DataTable
         setColumnSort={setColumnSort}

--- a/src/data/components/RowCount.tsx
+++ b/src/data/components/RowCount.tsx
@@ -6,15 +6,15 @@ const useStyles = makeStyles({
     textAlign: 'right',
     padding: '10px 15px',
     fontWeight: 'bold',
+    width: '100%',
   },
 })
 
 interface RowCountProps {
   children: React.ReactNode
 }
-const RowCount = ({ children }: RowCountProps) => {
+
+export function RowCount({ children }: RowCountProps) {
   const classes = useStyles()
   return <div className={classes.root}>{children}</div>
 }
-
-export default RowCount

--- a/src/data/components/table/DataTable.tsx
+++ b/src/data/components/table/DataTable.tsx
@@ -5,18 +5,18 @@ import { TableCell, withStyles } from '@material-ui/core'
 import Paper from '@material-ui/core/Paper'
 import {
   AutoSizer,
-  Column,
+  Column as VirtualizedColumn,
   Index,
   Table,
   TableRowProps,
 } from 'react-virtualized'
 import CharacterLimitBox from './components/CharacterLimitBox'
 import { ColumnSort } from '../../DDTable'
-import { Columns } from '../../types'
+import { Column } from '../../types'
 import { EmployeeTableResponse } from '../../../api/data/employee/employeeApiTypes'
 
 interface DataTableProps {
-  columns: Columns[]
+  columns: Column[]
   rows: EmployeeTableResponse[]
   setColumnSort?: (CurrentSort: ColumnSort) => void
   checkBoxChangeHandler?: () => void
@@ -99,7 +99,6 @@ export const tableStyles = makeStyles((theme: Theme) =>
 
 const DEFAULT_CELL_HEIGHT = 70
 const EXPANDED_CELL_HEIGHT = 522
-const COLUMNS_WIDTH = [385, 222, 143, 337, 53]
 
 function VirtualizedTable({
   columns,
@@ -191,10 +190,7 @@ function VirtualizedTable({
       <div key={key} className={classes.column} style={style}>
         <div className={className}>
           {columns.map((column, columnIndex) => (
-            <div
-              key={columnIndex}
-              style={{ width: COLUMNS_WIDTH[columnIndex] }}
-            >
+            <div key={columnIndex} style={{ width: column.width }}>
               <Cell
                 CellType={column.renderCell}
                 rowId={rowId}
@@ -279,21 +275,21 @@ function VirtualizedTable({
           noRowsRenderer={EmptyRow}
           gridClassName={classes.noFocus}
         >
-          {columns.map(({ title, headerCell }, index) => (
-            <Column
-              key={title}
+          {columns.map((column, index) => (
+            <VirtualizedColumn
+              key={column.title}
               headerRenderer={() =>
                 renderHeaderCell(
-                  title,
+                  column.title,
                   index,
                   currentColumnSort,
-                  headerCell,
+                  column.headerCell,
                   checkBoxChangeHandler
                 )
               }
               className={classes.flexContainer}
               dataKey={String(index)}
-              width={COLUMNS_WIDTH[index]}
+              width={column.width}
             />
           ))}
         </Table>

--- a/src/data/types.tsx
+++ b/src/data/types.tsx
@@ -18,8 +18,9 @@ export type ChartVariant = {
   }
 }
 
-export type Columns = {
+export type Column = {
   title: string
+  width: number
   isExpandable?: boolean
   checkBoxLabel?: string
   getSearchValue?: GetSearchValueFn
@@ -40,7 +41,7 @@ export interface DDComponentProps {
 
 export interface DDTableProps extends DDComponentProps {
   props: {
-    columns: Columns[]
+    columns: Column[]
   }
   initialFilters: FilterObject[]
 }

--- a/src/pages/customer/CustomerAccordion.tsx
+++ b/src/pages/customer/CustomerAccordion.tsx
@@ -32,7 +32,7 @@ interface CustomerDropdownProps {
   columns: Columns[]
 }
 
-export default function CustomerAccordion({
+export function CustomerAccordion({
   customerName,
   employees,
   expand = false,

--- a/src/pages/customer/CustomerAccordion.tsx
+++ b/src/pages/customer/CustomerAccordion.tsx
@@ -10,7 +10,7 @@ import React, { useState } from 'react'
 import { EmployeeTableResponse } from '../../api/data/employee/employeeApiTypes'
 import { GridItem } from '../../components/gridItem/GridItem'
 import DataTable from '../../data/components/table/DataTable'
-import { Columns } from '../../data/types'
+import { Column } from '../../data/types'
 
 const useStyles = makeStyles(() =>
   createStyles({
@@ -29,7 +29,7 @@ interface CustomerDropdownProps {
   customerName: string
   employees: EmployeeTableResponse[]
   expand?: boolean
-  columns: Columns[]
+  columns: Column[]
 }
 
 export function CustomerAccordion({

--- a/src/pages/customer/CustomerAccordion.tsx
+++ b/src/pages/customer/CustomerAccordion.tsx
@@ -32,7 +32,7 @@ interface CustomerDropdownProps {
   columns: Columns[]
 }
 
-export default function CustomerDropdown({
+export default function CustomerAccordion({
   customerName,
   employees,
   expand = false,

--- a/src/pages/customer/CustomerFilter.tsx
+++ b/src/pages/customer/CustomerFilter.tsx
@@ -1,42 +1,18 @@
 import * as React from 'react'
 import SearchInput from '../../components/SearchInput'
-import { SearchableColumn } from '../../data/DDTable'
-import {
-  CategoryWithGroup,
-  searchAndFilter,
-} from '../../components/filter/FilterUtil'
-import { EmployeeTableResponse } from '../../api/data/employee/employeeApiTypes'
 import { GridItemHeader } from '../../components/gridItem/GridItemHeader'
 
 interface CustomerFilterProps {
-  title: string
-  onFilter: (filteredRows: EmployeeTableResponse[]) => void
-  employees: EmployeeTableResponse[]
-  searchableColumns: SearchableColumn[]
-  categories: CategoryWithGroup[]
+  onSearch: (searchTerm: string) => void
 }
 
-export default function CustomerFilter({
-  title,
-  onFilter,
-  employees,
-  searchableColumns,
-}: CustomerFilterProps) {
-  const handleSearchChange = (searchTerm: string) => {
-    const filteredRows = searchAndFilter(
-      employees,
-      searchableColumns,
-      searchTerm
-    )
-    onFilter(filteredRows)
-  }
-
+export function CustomerFilter({ onSearch }: CustomerFilterProps) {
   return (
-    <GridItemHeader title={title} green>
+    <GridItemHeader title="Filtre" green>
       <SearchInput
         placeholder={'Søk på konsulentnavn eller kunde'}
-        onSearch={(searchTerm) => handleSearchChange(searchTerm)}
-        onClear={() => onFilter(employees)}
+        onSearch={onSearch}
+        onClear={() => onSearch('')}
       />
     </GridItemHeader>
   )

--- a/src/pages/customer/CustomerList.tsx
+++ b/src/pages/customer/CustomerList.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useState } from 'react'
 import { Grid } from '@material-ui/core'
 import { Skeleton } from '@material-ui/lab'
 import EmployeeInfo from '../employee/components/EmployeeInfo'
@@ -10,8 +11,11 @@ import {
 } from '../../data/components/table/DataCells'
 import { FallbackMessage } from '../employee/components/FallbackMessage'
 import { useEmployeesByCustomer } from '../../api/data/customer/customerQueries'
-import CustomerAccordion from './CustomerAccordion'
+import { CustomerAccordion } from './CustomerAccordion'
 import { Columns } from '../../data/types'
+import { CustomerFilter } from './CustomerFilter'
+import { getSearchableColumns } from '../../data/DDTable'
+import { searchEmployeesByCustomer } from './util/searchEmployeesByCustomer'
 
 const customerColumns: Columns[] = [
   {
@@ -38,7 +42,7 @@ const customerColumns: Columns[] = [
 ]
 
 export default function CustomerList() {
-  // const [searchTerm, setSearchTerm] = useState('')
+  const [searchTerm, setSearchTerm] = useState('')
   const { data, error } = useEmployeesByCustomer()
   const isLoading = !data
 
@@ -51,18 +55,20 @@ export default function CustomerList() {
     )
   }
 
-  // const filteredData = searchEmployeesByCustomer(
-  //   data,
-  //   getSearchableColumns(customerColumns),
-  //   searchTerm
-  // )
+  const filteredData = data
+    ? searchEmployeesByCustomer(
+        data,
+        getSearchableColumns(customerColumns),
+        searchTerm
+      )
+    : []
 
   const getCustomerAccordions = () => {
     if (isLoading) {
       return <Skeleton width={'100%'} animation="wave" />
     }
 
-    if (data.length === 0) {
+    if (filteredData.length === 0) {
       return (
         <GridItem fullSize>
           <div style={{ padding: '5px' }}>Ingen treff.</div>
@@ -70,7 +76,7 @@ export default function CustomerList() {
       )
     }
 
-    return data
+    return filteredData
       .sort(
         ({ customer_name: aCustomerName }, { customer_name: bCustomerName }) =>
           String(aCustomerName).localeCompare(bCustomerName)
@@ -87,11 +93,11 @@ export default function CustomerList() {
 
   return (
     <Grid container>
-      {/*isLoading ? (
+      {isLoading ? (
         <Skeleton width={'100%'} animation="wave" />
       ) : (
         <CustomerFilter onSearch={setSearchTerm} />
-      )*/}
+      )}
 
       {getCustomerAccordions()}
     </Grid>

--- a/src/pages/customer/CustomerList.tsx
+++ b/src/pages/customer/CustomerList.tsx
@@ -12,14 +12,15 @@ import {
 import { FallbackMessage } from '../employee/components/FallbackMessage'
 import { useEmployeesByCustomer } from '../../api/data/customer/customerQueries'
 import { CustomerAccordion } from './CustomerAccordion'
-import { Columns } from '../../data/types'
+import { Column } from '../../data/types'
 import { CustomerFilter } from './CustomerFilter'
 import { getSearchableColumns } from '../../data/DDTable'
 import { searchEmployeesByCustomer } from './util/searchEmployeesByCustomer'
 
-const customerColumns: Columns[] = [
+const customerColumns: Column[] = [
   {
     title: 'Konsulent',
+    width: 385,
     isExpandable: true,
     getSearchValue: (consultant: { value: string }) => {
       return consultant.value
@@ -27,15 +28,17 @@ const customerColumns: Columns[] = [
     renderCell: ConsultantCell,
     renderExpanded: EmployeeInfo,
   },
-  { title: 'Tittel' },
+  { title: 'Tittel', width: 222 },
   {
     title: 'Kunde',
+    width: 480,
     getSearchValue: (customerProject: string) => {
       return customerProject
     },
   },
   {
     title: 'CV',
+    width: 53,
     renderCell: CvCell,
     headerCell: CenteredHeaderCell,
   },

--- a/src/pages/customer/CustomerList.tsx
+++ b/src/pages/customer/CustomerList.tsx
@@ -16,6 +16,7 @@ import { Column } from '../../data/types'
 import { CustomerFilter } from './CustomerFilter'
 import { getSearchableColumns } from '../../data/DDTable'
 import { searchEmployeesByCustomer } from './util/searchEmployeesByCustomer'
+import { RowCount } from '../../data/components/RowCount'
 
 const customerColumns: Column[] = [
   {
@@ -99,7 +100,12 @@ export default function CustomerList() {
       {isLoading ? (
         <Skeleton width={'100%'} animation="wave" />
       ) : (
-        <CustomerFilter onSearch={setSearchTerm} />
+        <>
+          <CustomerFilter onSearch={setSearchTerm} />
+          <RowCount>
+            Viser {filteredData.length} av {data.length} kunder
+          </RowCount>
+        </>
       )}
 
       {getCustomerAccordions()}

--- a/src/pages/customer/CustomerList.tsx
+++ b/src/pages/customer/CustomerList.tsx
@@ -1,23 +1,19 @@
+import * as React from 'react'
 import { Grid } from '@material-ui/core'
 import { Skeleton } from '@material-ui/lab'
-import React, { useEffect, useState, useCallback } from 'react'
-import { EmployeeTableResponse } from '../../api/data/employee/employeeApiTypes'
-import { useEmployeeTable } from '../../api/data/employee/employeeQueries'
 import EmployeeInfo from '../employee/components/EmployeeInfo'
-import { useCategories } from '../../components/filter/FilterUtil'
 import { GridItem } from '../../components/gridItem/GridItem'
-import { CustomerStatusData } from '../../data/components/table/cells/CustomerStatusCell'
 import {
   CenteredHeaderCell,
   ConsultantCell,
-  CustomerStatusCell,
   CvCell,
 } from '../../data/components/table/DataCells'
-import { getSearchableColumns } from '../../data/DDTable'
-import CustomerDropdown from './CustomerDropdown'
-import CustomerFilter from './CustomerFilter'
+import { FallbackMessage } from '../employee/components/FallbackMessage'
+import { useEmployeesByCustomer } from '../../api/data/customer/customerQueries'
+import CustomerAccordion from './CustomerAccordion'
+import { Columns } from '../../data/types'
 
-const CustomerColumns = [
+const customerColumns: Columns[] = [
   {
     title: 'Konsulent',
     isExpandable: true,
@@ -30,9 +26,8 @@ const CustomerColumns = [
   { title: 'Tittel' },
   {
     title: 'Kunde',
-    renderCell: CustomerStatusCell,
-    getSearchValue: (customer: CustomerStatusData) => {
-      return `${customer.customer} ${customer.workOrderDescription}`
+    getSearchValue: (customerProject: string) => {
+      return customerProject
     },
   },
   {
@@ -42,106 +37,63 @@ const CustomerColumns = [
   },
 ]
 
-type EmployeeGroupedCustomers = Record<string, EmployeeTableResponse[]>
 export default function CustomerList() {
-  const [initialData, setInitialData] = useState<EmployeeTableResponse[]>([])
-  const [dropdowns, setDropdowns] = useState<JSX.Element[]>([])
-  const { data: employeeData, error } = useEmployeeTable()
+  // const [searchTerm, setSearchTerm] = useState('')
+  const { data, error } = useEmployeesByCustomer()
+  const isLoading = !data
 
-  const categories = useCategories()
-
-  const pending = !employeeData && error
-
-  function groupByCustomers(
-    employees: EmployeeTableResponse[],
-    columnIndex: number
-  ) {
-    return employees.reduce(
-      (groups: EmployeeGroupedCustomers, employee: EmployeeTableResponse) => {
-        const group = groups[employee.rowData[columnIndex].customer] || []
-        group.push(employee)
-        groups[employee.rowData[columnIndex].customer] = group
-        return groups
-      },
-      {}
+  if (error) {
+    return (
+      <FallbackMessage
+        isError
+        message="Det oppstod en feil ved henting av data."
+      />
     )
   }
 
-  const createDropDowns = useCallback(
-    (customers: EmployeeGroupedCustomers, expand?: boolean) => {
-      const dropdowns: JSX.Element[] = []
-      !pending &&
-        customers &&
-        Object.keys(customers)
-          .sort()
-          .forEach((customer) =>
-            dropdowns.push(
-              <CustomerDropdown
-                key={`${customer}`}
-                customerName={customer}
-                employees={customers[customer]}
-                expand={expand}
-                columns={CustomerColumns}
-              />
-            )
-          )
-      setDropdowns(dropdowns)
-    },
-    [pending]
-  )
+  // const filteredData = searchEmployeesByCustomer(
+  //   data,
+  //   getSearchableColumns(customerColumns),
+  //   searchTerm
+  // )
 
-  const handleSearchAndFilter = (filtered: EmployeeTableResponse[]) => {
-    const expand = filtered.length === initialData.length
-    const grouped = groupByCustomers(filtered, 2)
-    createDropDowns(grouped, !expand)
-  }
-
-  const prepareTablePayLoad = useCallback(() => {
-    const statusIconData = 2
-    const customerData = 3
-
-    if (employeeData && !pending) {
-      employeeData.map((employee) => {
-        if (!employee.rowData[customerData].customer) {
-          employee.rowData[customerData] = { customer: 'Ikke i prosjekt' }
-        }
-        employee.rowData.splice(statusIconData, 1)
-      })
-      setInitialData(employeeData)
-      const groups = groupByCustomers(employeeData, 2) // customerIndex changes after splice
-      createDropDowns(groups)
+  const getCustomerAccordions = () => {
+    if (isLoading) {
+      return <Skeleton width={'100%'} animation="wave" />
     }
-  }, [createDropDowns, employeeData, pending])
 
-  useEffect(() => {
-    if (employeeData) {
-      prepareTablePayLoad()
-    }
-  }, [employeeData, prepareTablePayLoad])
-
-  return (
-    <Grid container>
-      {pending ? (
-        <Skeleton width={'100%'} animation="wave" />
-      ) : (
-        <CustomerFilter
-          title="Filtre"
-          onFilter={handleSearchAndFilter}
-          employees={initialData}
-          searchableColumns={getSearchableColumns(CustomerColumns)}
-          categories={categories}
-        />
-      )}
-
-      {!dropdowns || pending ? (
-        <Skeleton width={'100%'} animation="wave" />
-      ) : dropdowns.length > 0 ? (
-        dropdowns
-      ) : (
+    if (data.length === 0) {
+      return (
         <GridItem fullSize>
           <div style={{ padding: '5px' }}>Ingen treff.</div>
         </GridItem>
-      )}
+      )
+    }
+
+    return data
+      .sort(
+        ({ customer_name: aCustomerName }, { customer_name: bCustomerName }) =>
+          String(aCustomerName).localeCompare(bCustomerName)
+      )
+      .map(({ customer_name, employees }) => (
+        <CustomerAccordion
+          key={customer_name}
+          customerName={customer_name}
+          employees={employees}
+          columns={customerColumns}
+        />
+      ))
+  }
+
+  return (
+    <Grid container>
+      {/*isLoading ? (
+        <Skeleton width={'100%'} animation="wave" />
+      ) : (
+        <CustomerFilter onSearch={setSearchTerm} />
+      )*/}
+
+      {getCustomerAccordions()}
     </Grid>
   )
 }

--- a/src/pages/customer/util/searchEmployeesByCustomer.tsx
+++ b/src/pages/customer/util/searchEmployeesByCustomer.tsx
@@ -1,0 +1,25 @@
+import { CustomerWithEmployees } from '../../../api/data/customer/customerApiTypes'
+import { SearchableColumn } from '../../../data/DDTable'
+import { searchRow } from '../../../components/filter/FilterUtil'
+
+export function searchEmployeesByCustomer(
+  customerWithEmployees: CustomerWithEmployees[],
+  searchableColumns: SearchableColumn[],
+  searchTerm: string
+) {
+  return customerWithEmployees.reduce(
+    (customersWithMatchingEmployees, { customer_name, employees }) => {
+      const filteredEmployees = employees.filter((employee) =>
+        searchRow(employee, searchableColumns, searchTerm)
+      )
+      if (filteredEmployees.length > 0) {
+        customersWithMatchingEmployees.push({
+          customer_name,
+          employees: filteredEmployees,
+        })
+      }
+      return customersWithMatchingEmployees
+    },
+    [] as CustomerWithEmployees[]
+  )
+}

--- a/src/pages/employee/components/CvDownloadList.tsx
+++ b/src/pages/employee/components/CvDownloadList.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { Links } from '../../../api/data/employee/employeeApiTypes'
+import { CvLinks } from '../../../api/data/employee/employeeApiTypes'
 import { makeStyles } from '@material-ui/core/styles'
 import { MultiLineSkeleton } from '../../../components/skeletons/MultiLineSkeleton'
 import { mapLinkKeyToLabel } from '../../../utils/cvLinkHelpers'
@@ -27,7 +27,7 @@ const DownloadIcon = withStyles({
 })(GetApp)
 
 interface Props {
-  links?: Links
+  links?: CvLinks
   isLoading?: boolean
 }
 

--- a/src/pages/employee/components/EmployeeInfo.tsx
+++ b/src/pages/employee/components/EmployeeInfo.tsx
@@ -27,6 +27,7 @@ interface EmployeeInfoData {
   }
   workExperience: WorkExperience[]
   manager: string
+  degree?: string
   guid: string
 }
 
@@ -87,10 +88,8 @@ const useStyles = makeStyles((theme: Theme) =>
 
 interface EmployeeInfoProps {
   data: {
-    competenceUrl: string
     user_id: string
-    email_id: string
-    degree: string
+    email: string
   }
   id: string
   setRowHeight: (id: string, height: number) => void
@@ -105,21 +104,27 @@ function getStringFromList(list: string[] | undefined) {
 
 export default function EmployeeInfo({ data }: EmployeeInfoProps) {
   const classes = useStyles()
-  const url = data.competenceUrl
-  const [empData, pending] = useFetchedData<EmployeeInfoData>({ url })
-  const user_id = data.user_id
+  const [empData, pending] = useFetchedData<EmployeeInfoData>({
+    url: `/api/data/employeeCompetence?email=${data.email}`,
+  })
   const [expData, expPending] = useFetchedData<EmployeeExperienceResponse>({
-    url: `/api/data/employeeExperience?user_id=${user_id}`,
+    url: `/api/data/employeeExperience?user_id=${data.user_id}`,
   })
 
-  const { data: employeeChartData } = useEmployeeRadar(data.email_id)
+  const { data: employeeChartData } = useEmployeeRadar(data.email)
 
   return (
     <div className={classes.root}>
       <div className={classes.info}>
         <div className={classes.cell}>
-          <b>Utdanning: </b>
-          {data.degree}
+          {pending ? (
+            <Skeleton variant="rect" width={340} height={15} animation="wave" />
+          ) : (
+            <>
+              <b>Utdanning: </b>
+              {empData?.degree}
+            </>
+          )}
         </div>
         <div className={classes.cell}>
           {pending ? (

--- a/src/pages/employee/components/EmployeeTable.tsx
+++ b/src/pages/employee/components/EmployeeTable.tsx
@@ -32,6 +32,7 @@ export function EmployeeTable() {
             columns: [
               {
                 title: 'Konsulent',
+                width: 385,
                 isExpandable: true,
                 getSearchValue: (consultant: { value: string }) => {
                   return consultant.value
@@ -43,14 +44,20 @@ export function EmployeeTable() {
               },
               {
                 title: 'Tittel',
+                width: 222,
                 headerCell: SortableHeaderCell,
                 getSearchValue: (jobTitle: string | undefined | null) => {
                   return jobTitle
                 },
               },
-              { title: 'Prosjektstatus', renderCell: ProjectStatusCell },
+              {
+                title: 'Prosjektstatus',
+                width: 143,
+                renderCell: ProjectStatusCell,
+              },
               {
                 title: 'Kunde',
+                width: 337,
                 renderCell: CustomerStatusCell,
                 getSearchValue: (customer: CustomerStatusData) => {
                   return customer.customer
@@ -59,7 +66,7 @@ export function EmployeeTable() {
                 },
                 headerCell: SortableHeaderCell,
               },
-              { title: 'CV', renderCell: CvCell },
+              { title: 'CV', width: 53, renderCell: CvCell },
             ],
           }}
           initialFilters={[

--- a/src/tests/EmployeeInfo.test.tsx
+++ b/src/tests/EmployeeInfo.test.tsx
@@ -46,10 +46,8 @@ const fakeUser = {
 }
 
 const mockData = {
-  competenceUrl: '/404',
   user_id: '123',
-  email_id: '123',
-  degree: 'some degree',
+  email: '123',
 }
 
 jest.mock('../hooks/service', () => ({

--- a/src/utils/cvLinkHelpers.ts
+++ b/src/utils/cvLinkHelpers.ts
@@ -1,13 +1,13 @@
-import { Links } from '../api/data/employee/employeeApiTypes'
+import { CvLinks } from '../api/data/employee/employeeApiTypes'
 
-const linkLabels: Record<keyof Links, string> = {
+const linkLabels: Record<keyof CvLinks, string> = {
   no_pdf: 'Norsk, PDF',
   int_pdf: 'Engelsk, PDF',
   no_word: 'Norsk, Word',
   int_word: 'Engelsk, Word',
 }
 
-export function isValidLinkKey(linkKey: string): linkKey is keyof Links {
+export function isValidLinkKey(linkKey: string): linkKey is keyof CvLinks {
   return ['no_pdf', 'int_pdf', 'no_word', 'int_word'].includes(linkKey)
 }
 


### PR DESCRIPTION
Created a new report (`employeesWithPrimaryCustomer`) and separate endpoint (`emplyeesByCustomer`) for the customer list ([#619](https://github.com/knowit/Dataplattform-issues/issues/619)). Only necessary data is fetched, reducing the latency caused by data transfer and aggregation/processing that was a problem when using the `employeeTable` endpoint.
  * Employees without customers are not included in the report (fixes [#590](https://github.com/knowit/Dataplattform-issues/issues/590))
  * The new endpoint returns employees grouped by customer – made it easy to implement a filtering counter (fixes [#618](https://github.com/knowit/Dataplattform-issues/issues/618))
  * Reduced need for data processing in the frontend (fixes bug in [#616](https://github.com/knowit/Dataplattform-issues/issues/616))

Made some small adjustments to how the employee table works:
* Column width is now declared as part of the `Column` type, allowing for flexible widths (fixes part of [#616](https://github.com/knowit/Dataplattform-issues/issues/616)).
* Loosened the coupling between a row entry in the table and the expanded info-box (`EmployeeInfo.tsx`) for a row. Logic for `competenceUrl` field moved to frontend and `degree` field moved to `employeeCompetence` endpoint. This allows the `employeesByCustomer` to send less data per employee table row.

Also:
* Created a common CV link generation function in backend
* Adjusted styling of `GridItemHeader` for better accessibility (and removed redundant styles in `GridItem`)