### PR TITLE
Feature/employee profile improvements

### DIFF
--- a/backend/repository/data.ts
+++ b/backend/repository/data.ts
@@ -1,11 +1,4 @@
-import {
-  mapEmployeeTags,
-  getEventSet,
-  mergeCustomersForEmployees,
-  range,
-  sum,
-} from './util'
-import Reporting from '../reporting'
+import { mapEmployeeTags, getEventSet, range, sum } from './util'
 import { LineChartData } from '../routers/chartTypes'
 
 type EmployeeMotivationAndCompetence = {
@@ -17,21 +10,6 @@ type EmployeeMotivationAndCompetence = {
   categoryMotivationAvg: number
   categoryCompetenceAvg: number
 }
-
-const getStorageUrl = (key: string) => {
-  if (key !== undefined) {
-    return `${process.env.STORAGE_URL}/${key}`
-  } else {
-    return undefined
-  }
-}
-
-const cvs = [
-  ['no', 'pdf'],
-  ['int', 'pdf'],
-  ['no', 'word'],
-  ['int', 'word'],
-]
 
 type ReportParams = {
   parameters: {
@@ -504,56 +482,6 @@ export const competenceAmount = async ({
   return {
     setNames: Object.keys(output),
     sets: output,
-  }
-}
-
-export const employeeProfileReports = ({
-  parameters: { email } = {},
-}: ReportParams) => [
-  {
-    reportName: 'employeeSkills',
-    filter: { email },
-  },
-  {
-    reportName: 'workExperience',
-    filter: { email },
-  },
-  {
-    reportName: 'employeeInformation',
-    filter: { email },
-  },
-]
-
-/**
- * Dette endepunktet henter data om en enkelt person for å fylle opp sidene for hver enkelt ansatt.
- */
-export const employeeProfile = async ({ data }: EmployeeData) => {
-  const [employeeSkills, workExperience, employeeInformation] = data
-
-  if (!employeeInformation || employeeInformation.length === 0) {
-    throw Reporting({ status: 404, message: 'No employee information found' })
-  }
-
-  const employee = mergeCustomersForEmployees(employeeInformation)[0]
-
-  return {
-    user_id: employee.user_id,
-    guid: employee.guid,
-    navn: employee.navn,
-    manager: employee.manager,
-    title: employee.title,
-    degree: employee.degree,
-    email: employee.email,
-    image: getStorageUrl(employee.image_key),
-    customers: employee.customers,
-    workExperience,
-    tags: mapEmployeeTags(employeeSkills[0]),
-    links: Object.fromEntries(
-      cvs.map(([lang, format]) => [
-        `${lang}_${format}`,
-        employee.link?.replace('{LANG}', lang).replace('{FORMAT}', format),
-      ])
-    ),
   }
 }
 

--- a/backend/repository/reports.js
+++ b/backend/repository/reports.js
@@ -30,6 +30,20 @@ const reports = [
     lastCacheUpdate: '2022-03-28T13:36:22.390506',
   },
   {
+    name: 'employeeProfileInformation',
+    queryString:
+      'WITH last_education AS (SELECT a.user_id, array_agg(a.degree)[1] AS degree, array_agg(a.year_to)[1] AS year_to FROM dev_level_3_database.cv_partner_education a INNER JOIN (SELECT user_id, max(year_to) AS year_to FROM dev_level_3_database.cv_partner_education GROUP BY user_id) b ON a.user_id = b.user_id AND a.year_to = b.year_to GROUP BY a.user_id) SELECT cv.user_id, cv.guid, cv.email, cv.navn AS name, cv.telefon AS phone, cv.title, edu.degree, ad.manager, cv.image_key, cv.link FROM dev_level_3_database.cv_partner_employees AS cv LEFT OUTER JOIN last_education AS edu ON edu.user_id = cv.user_id LEFT OUTER JOIN dev_level_3_database.active_directory AS ad ON ad.guid = cv.guid ORDER BY name',
+    tables: [
+      'active_directory',
+      'cv_partner_education',
+      'cv_partner_employees',
+    ],
+    dataProtection: 3,
+    created: '2022-04-01T07:43:15.177430',
+    lastUsed: null,
+    lastCacheUpdate: '2022-04-01T07:43:17.614737',
+  },
+  {
     name: 'competence',
     queryString:
       'WITH last_education AS (SELECT a.user_id, array_agg(a.degree)[1] AS degree, array_agg(a.year_to)[1] AS year_to FROM dev_level_3_database.cv_partner_education a INNER JOIN (SELECT user_id, max(year_to) AS year_to FROM dev_level_3_database.cv_partner_education GROUP BY  user_id ) b ON a.user_id = b.user_id AND a.year_to = b.year_to GROUP BY  a.user_id) SELECT emp.user_id, navn, title, link, degree, email, image_key\n FROM dev_level_3_database.cv_partner_employees AS emp LEFT OUTER JOIN last_education AS e ON e.user_id = emp.user_id order by navn',

--- a/backend/repository/reports.js
+++ b/backend/repository/reports.js
@@ -293,12 +293,12 @@ const reports = [
   {
     name: 'projectExperience',
     queryString:
-      'SELECT emp.user_id, navn, customer, description, year_from, year_to, month_from,  month_to FROM dev_level_3_database.cv_partner_project_experience AS exp JOIN (SELECT user_id, navn FROM dev_level_3_database.cv_partner_employees) emp ON exp.user_id = emp.user_id',
+      'SELECT emp.user_id, email, navn, customer, description, year_from, year_to, month_from, month_to FROM dev_level_3_database.cv_partner_project_experience AS exp JOIN (SELECT user_id, navn, email FROM dev_level_3_database.cv_partner_employees) emp ON exp.user_id = emp.user_id',
     tables: ['cv_partner_employees', 'cv_partner_project_experience'],
     dataProtection: 3,
-    created: '2021-07-28T10:38:43.562688',
+    created: '2022-04-01T08:26:31.053906',
     lastUsed: null,
-    lastCacheUpdate: '2022-01-21T10:08:57.380277',
+    lastCacheUpdate: '2022-04-01T08:26:37.031550',
   },
   {
     name: 'test123',

--- a/backend/repository/util.ts
+++ b/backend/repository/util.ts
@@ -1,4 +1,4 @@
-import { EmployeeInformation, EmployeeSkills } from './data'
+import { EmployeeSkills } from './data'
 import AWS from 'aws-sdk'
 AWS.config.update({ region: 'eu-central-1' })
 
@@ -8,50 +8,6 @@ export const range = (x: number, y: number) =>
       while (x <= y) yield x++
     })()
   )
-
-type EmployeeWithMergedCustomers = EmployeeInformation & {
-  customers: Customer[]
-}
-
-type Customer = {
-  customer: string
-  workOrderDescription: string
-  weight: number
-}
-
-/**
- * Receives a list of employees, where each employee is listed once for each
- * customer it is related to. This means that an employee might be listed more
- * than once. The function merges the received employees and returns a list of
- * distinct employees, each with a merged list of their related customers.
- */
-export const mergeCustomersForEmployees = (
-  employees: EmployeeInformation[]
-): EmployeeWithMergedCustomers[] => {
-  const employeesWithMergedCustomers = {}
-
-  employees.forEach((employee) => {
-    const employeeToMerge =
-      employeesWithMergedCustomers[employee.guid] ?? employee
-    const customersForEmployee = employeeToMerge.customers ?? []
-
-    if (employee.customer) {
-      const thisCustomer = {
-        customer: employee.customer,
-        workOrderDescription: employee.work_order_description,
-        weight: employee.weight,
-      }
-      customersForEmployee.push(thisCustomer)
-    }
-
-    employeesWithMergedCustomers[employee.guid] = {
-      ...employeeToMerge,
-      customers: customersForEmployee,
-    }
-  })
-
-  return Object.values(employeesWithMergedCustomers)
-}
 
 export function mapEmployeeTags(employeeSkills?: EmployeeSkills) {
   const { skill, language, role } = employeeSkills ?? {}

--- a/backend/routers/customer/customerRouter.ts
+++ b/backend/routers/customer/customerRouter.ts
@@ -7,7 +7,7 @@ import {
 import {
   BilledCustomerHours,
   EmployeeWithPrimaryCustomer,
-  EmployeeCustomers,
+  EmployeeCustomersReport,
 } from './customerTypes'
 import {
   groupEmployeesByCustomer,
@@ -50,7 +50,7 @@ router.get('/customerCards', async (req, res, next) => {
       accessToken: req.accessToken,
       reportName: 'perProject',
     })
-    const employeeCustomers = await getReport<EmployeeCustomers[]>({
+    const employeeCustomers = await getReport<EmployeeCustomersReport>({
       accessToken: req.accessToken,
       reportName: 'employeeCustomers',
     })

--- a/backend/routers/customer/customerTypes.ts
+++ b/backend/routers/customer/customerTypes.ts
@@ -42,6 +42,7 @@ export type CustomerCardsData = {
   billedTotal: number
 }
 
+export type EmployeeCustomersReport = EmployeeCustomers[]
 export type EmployeeCustomers = {
   user_id: string
   email: string

--- a/backend/routers/employees/aggregationHelpers.ts
+++ b/backend/routers/employees/aggregationHelpers.ts
@@ -1,10 +1,8 @@
 import {
   CategoryScores,
   CvLinks,
-  EmployeeInformation,
   EmployeeMotivationAndCompetence,
   EmployeeSkills,
-  EmployeeWithMergedCustomers,
   EmployeeWorkStatus,
   JobRotationInformation,
   JobRotationStatus,
@@ -17,40 +15,6 @@ export const getStorageUrl = (key?: string) => {
     return
   }
   return `${process.env.STORAGE_URL}/${key}`
-}
-
-/**
- * Receives a list of employees, where each employee is listed once for each
- * customer it is related to. This means that an employee might be listed more
- * than once. The function merges the received employees and returns a list of
- * distinct employees, each with a merged list of their related customers.
- */
-export const mergeCustomersForEmployees = (
-  employees: EmployeeInformation[]
-): EmployeeWithMergedCustomers[] => {
-  const employeesWithMergedCustomers = {}
-
-  employees.forEach((employee) => {
-    const employeeToMerge: EmployeeWithMergedCustomers =
-      employeesWithMergedCustomers[employee.guid] ?? employee
-    const customersForEmployee = employeeToMerge.customers ?? []
-
-    if (employee.customer) {
-      const thisCustomer = {
-        customer: employee.customer,
-        workOrderDescription: employee.work_order_description,
-        weight: employee.weight,
-      }
-      customersForEmployee.push(thisCustomer)
-    }
-
-    employeesWithMergedCustomers[employee.guid] = {
-      ...employeeToMerge,
-      customers: customersForEmployee,
-    }
-  })
-
-  return Object.values(employeesWithMergedCustomers)
 }
 
 export function mapEmployeeTags(employeeSkills?: EmployeeSkills): Tags {

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -3,13 +3,12 @@ import {
   getProjectStatusForEmployee,
   getCategoryScoresForEmployee,
   getStorageUrl,
-  mergeCustomersForEmployees,
   createCvLinks,
 } from './aggregationHelpers'
 import {
   BasicEmployeeInformation,
   EmployeeExperience,
-  EmployeeInformation,
+  EmployeeProfileInformation,
   EmployeeMotivationAndCompetence,
   EmployeeProfileResponse,
   EmployeeSkills,
@@ -18,6 +17,7 @@ import {
   JobRotationInformation,
   WorkExperience,
 } from './employeesTypes'
+import { EmployeeCustomers } from '../customer/customerTypes'
 
 export const aggregateEmployeeTable = (
   basicEmployeeInformation: BasicEmployeeInformation[],
@@ -118,26 +118,30 @@ export const aggregateEmployeeCompetenceAndMotivation = (
 export const aggregateEmployeeProfile = (
   employeeSkills: EmployeeSkills[],
   workExperience: WorkExperience[],
-  employeeInformation: EmployeeInformation[]
+  employeeInformation: EmployeeProfileInformation[],
+  employeeCustomers: EmployeeCustomers[]
 ): EmployeeProfileResponse => {
   if (employeeInformation.length === 0) {
     return
   }
 
-  const employee = mergeCustomersForEmployees(employeeInformation)[0]
+  const employee = employeeInformation[0]
 
   return {
     user_id: employee.user_id,
-    guid: employee.guid,
-    navn: employee.navn,
-    manager: employee.manager,
-    title: employee.title,
-    degree: employee.degree,
     email: employee.email,
+    name: employee.name,
+    title: employee.title,
+    phone: employee.phone,
+    degree: employee.degree,
+    manager: employee.manager,
     image: getStorageUrl(employee.image_key),
-    customers: employee.customers,
     workExperience,
     tags: mapEmployeeTags(employeeSkills[0]),
     links: createCvLinks(employee.link),
+    customers: employeeCustomers.map((customer) => ({
+      customer: customer.customer,
+      workOrderDescription: customer.work_order_description,
+    })),
   }
 }

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -7,7 +7,7 @@ import {
 } from './aggregationHelpers'
 import {
   BasicEmployeeInformation,
-  EmployeeExperience,
+  ProjectExperience,
   EmployeeProfileInformation,
   EmployeeMotivationAndCompetence,
   EmployeeProfileResponse,
@@ -57,7 +57,7 @@ export const aggregateEmployeeTable = (
   })
 }
 
-export const aggregateEmployeeExperience = (data: EmployeeExperience[]) => {
+export const aggregateEmployeeExperience = (data: ProjectExperience[]) => {
   const formatTime = (year: number, month: number) =>
     [
       year && year > 0 ? year : '',

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -118,14 +118,14 @@ export const aggregateEmployeeCompetenceAndMotivation = (
 export const aggregateEmployeeProfile = (
   employeeSkills: EmployeeSkills[],
   workExperience: WorkExperience[],
-  employeeInformation: EmployeeProfileInformation[],
+  employeeProfileInformation: EmployeeProfileInformation[],
   employeeCustomers: EmployeeCustomers[]
 ): EmployeeProfileResponse => {
-  if (employeeInformation.length === 0) {
+  if (employeeProfileInformation.length === 0) {
     return
   }
 
-  const employee = employeeInformation[0]
+  const employee = employeeProfileInformation[0]
 
   return {
     user_id: employee.user_id,

--- a/backend/routers/employees/employeesAggregation.ts
+++ b/backend/routers/employees/employeesAggregation.ts
@@ -116,9 +116,10 @@ export const aggregateEmployeeCompetenceAndMotivation = (
 }
 
 export const aggregateEmployeeProfile = (
+  employeeProfileInformation: EmployeeProfileInformation[],
   employeeSkills: EmployeeSkills[],
   workExperience: WorkExperience[],
-  employeeProfileInformation: EmployeeProfileInformation[],
+  projectExperience: ProjectExperience[],
   employeeCustomers: EmployeeCustomers[]
 ): EmployeeProfileResponse => {
   if (employeeProfileInformation.length === 0) {
@@ -136,9 +137,23 @@ export const aggregateEmployeeProfile = (
     degree: employee.degree,
     manager: employee.manager,
     image: getStorageUrl(employee.image_key),
-    workExperience,
     tags: mapEmployeeTags(employeeSkills[0]),
     links: createCvLinks(employee.link),
+    workExperience: workExperience.map((job) => ({
+      employer: job.employer,
+      month_from: job.month_from,
+      month_to: job.month_to,
+      year_from: job.year_from,
+      year_to: job.year_to,
+    })),
+    projectExperience: projectExperience.map((project) => ({
+      customer: project.customer,
+      project: project.description,
+      year_from: project.year_from,
+      month_from: project.month_from,
+      year_to: project.year_to,
+      month_to: project.month_to,
+    })),
     customers: employeeCustomers.map((customer) => ({
       customer: customer.customer,
       workOrderDescription: customer.work_order_description,

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -12,7 +12,7 @@ import {
 } from './employeesAggregation'
 import {
   BasicEmployeeInformationReport,
-  EmployeeExperienceReport,
+  ProjectExperienceReport,
   EmployeeProfileInformationReport,
   EmployeeMotivationAndCompetenceReport,
   EmployeeSkillsReport,
@@ -91,7 +91,7 @@ router.get<unknown, unknown, unknown, UserIdParam>(
         throw err
       }
 
-      const data = await getReport<EmployeeExperienceReport>({
+      const data = await getReport<ProjectExperienceReport>({
         accessToken: req.accessToken,
         reportName: 'projectExperience',
         queryParams: {

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -13,13 +13,14 @@ import {
 import {
   BasicEmployeeInformationReport,
   EmployeeExperienceReport,
-  EmployeeInformationReport,
+  EmployeeProfileInformationReport,
   EmployeeMotivationAndCompetenceReport,
   EmployeeSkillsReport,
   EmployeeWorkStatusReport,
   JobRotationInformationReport,
   WorkExperienceReport,
 } from './employeesTypes'
+import { EmployeeCustomersReport } from '../customer/customerTypes'
 
 const router = express.Router()
 
@@ -195,20 +196,34 @@ router.get<unknown, unknown, unknown, EmailParam>(
         },
       })
 
-      const employeeInformationPromise = getReport<EmployeeInformationReport>({
+      const employeeInformationPromise =
+        getReport<EmployeeProfileInformationReport>({
+          accessToken: req.accessToken,
+          reportName: 'employeeProfile',
+          queryParams: {
+            email: req.query.email,
+          },
+        })
+
+      const employeeCustomersPromise = getReport<EmployeeCustomersReport>({
         accessToken: req.accessToken,
-        reportName: 'employeeInformation',
+        reportName: 'employeeCustomers',
         queryParams: {
           email: req.query.email,
         },
       })
 
-      const [employeeSkills, workExperience, employeeInformation] =
-        await Promise.all([
-          employeeSkillsPromise,
-          workExperiencePromise,
-          employeeInformationPromise,
-        ])
+      const [
+        employeeSkills,
+        workExperience,
+        employeeInformation,
+        employeeCustomers,
+      ] = await Promise.all([
+        employeeSkillsPromise,
+        workExperiencePromise,
+        employeeInformationPromise,
+        employeeCustomersPromise,
+      ])
 
       if (!employeeInformation || employeeInformation.length === 0) {
         const err: NotFoundError = {
@@ -222,7 +237,8 @@ router.get<unknown, unknown, unknown, EmailParam>(
       const aggregatedData = aggregateEmployeeProfile(
         employeeSkills,
         workExperience,
-        employeeInformation
+        employeeInformation,
+        employeeCustomers
       )
 
       res.send(aggregatedData)

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -180,6 +180,15 @@ router.get<unknown, unknown, unknown, EmailParam>(
         throw err
       }
 
+      const employeeProfileInformationPromise =
+        getReport<EmployeeProfileInformationReport>({
+          accessToken: req.accessToken,
+          reportName: 'employeeProfileInformation',
+          queryParams: {
+            email: req.query.email,
+          },
+        })
+
       const employeeSkillsPromise = getReport<EmployeeSkillsReport>({
         accessToken: req.accessToken,
         reportName: 'employeeSkills',
@@ -196,14 +205,13 @@ router.get<unknown, unknown, unknown, EmailParam>(
         },
       })
 
-      const employeeProfileInformationPromise =
-        getReport<EmployeeProfileInformationReport>({
-          accessToken: req.accessToken,
-          reportName: 'employeeProfileInformation',
-          queryParams: {
-            email: req.query.email,
-          },
-        })
+      const projectExperiencePromise = getReport<ProjectExperienceReport>({
+        accessToken: req.accessToken,
+        reportName: 'projectExperience',
+        queryParams: {
+          email: req.query.email,
+        },
+      })
 
       const employeeCustomersPromise = getReport<EmployeeCustomersReport>({
         accessToken: req.accessToken,
@@ -214,14 +222,16 @@ router.get<unknown, unknown, unknown, EmailParam>(
       })
 
       const [
+        employeeProfileInformation,
         employeeSkills,
         workExperience,
-        employeeProfileInformation,
+        projectExperience,
         employeeCustomers,
       ] = await Promise.all([
+        employeeProfileInformationPromise,
         employeeSkillsPromise,
         workExperiencePromise,
-        employeeProfileInformationPromise,
+        projectExperiencePromise,
         employeeCustomersPromise,
       ])
 
@@ -238,9 +248,10 @@ router.get<unknown, unknown, unknown, EmailParam>(
       }
 
       const aggregatedData = aggregateEmployeeProfile(
+        employeeProfileInformation,
         employeeSkills,
         workExperience,
-        employeeProfileInformation,
+        projectExperience,
         employeeCustomers
       )
 

--- a/backend/routers/employees/employeesRouter.ts
+++ b/backend/routers/employees/employeesRouter.ts
@@ -196,10 +196,10 @@ router.get<unknown, unknown, unknown, EmailParam>(
         },
       })
 
-      const employeeInformationPromise =
+      const employeeProfileInformationPromise =
         getReport<EmployeeProfileInformationReport>({
           accessToken: req.accessToken,
-          reportName: 'employeeProfile',
+          reportName: 'employeeProfileInformation',
           queryParams: {
             email: req.query.email,
           },
@@ -216,16 +216,19 @@ router.get<unknown, unknown, unknown, EmailParam>(
       const [
         employeeSkills,
         workExperience,
-        employeeInformation,
+        employeeProfileInformation,
         employeeCustomers,
       ] = await Promise.all([
         employeeSkillsPromise,
         workExperiencePromise,
-        employeeInformationPromise,
+        employeeProfileInformationPromise,
         employeeCustomersPromise,
       ])
 
-      if (!employeeInformation || employeeInformation.length === 0) {
+      if (
+        !employeeProfileInformation ||
+        employeeProfileInformation.length === 0
+      ) {
         const err: NotFoundError = {
           status: 404,
           message: "Employee with email '" + req.query.email + "' not found.",
@@ -237,7 +240,7 @@ router.get<unknown, unknown, unknown, EmailParam>(
       const aggregatedData = aggregateEmployeeProfile(
         employeeSkills,
         workExperience,
-        employeeInformation,
+        employeeProfileInformation,
         employeeCustomers
       )
 

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -161,10 +161,28 @@ export type EmployeeProfileResponse = Omit<
   'guid' | 'image_key' | 'link'
 > & {
   image: string
-  workExperience: WorkExperience[]
   tags: Tags
   links: CvLinks
   customers: Customer[]
+  workExperience: WorkExperienceForProfile[]
+  projectExperience: ProjectExperienceForProfile[]
+}
+
+type WorkExperienceForProfile = {
+  employer: string
+  month_from: number
+  year_from: number
+  month_to: number
+  year_to: number
+}
+
+type ProjectExperienceForProfile = {
+  customer: string
+  project: string
+  year_from: number
+  month_from: number
+  year_to: number
+  month_to: number
 }
 
 export type Tags = {

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -85,9 +85,10 @@ export type WorkExperience = {
   year_to: number
 }
 
-export type EmployeeExperienceReport = EmployeeExperience[]
-export type EmployeeExperience = {
+export type ProjectExperienceReport = ProjectExperience[]
+export type ProjectExperience = {
   user_id: string
+  email: string
   navn: string
   customer: string
   description: string

--- a/backend/routers/employees/employeesTypes.ts
+++ b/backend/routers/employees/employeesTypes.ts
@@ -4,20 +4,18 @@ import { TableRow } from '../datatypes/typeData'
  * Employee Reports
  */
 
-export type EmployeeInformationReport = EmployeeInformation[]
-export type EmployeeInformation = {
+export type EmployeeProfileInformationReport = EmployeeProfileInformation[]
+export type EmployeeProfileInformation = {
   user_id: string
   guid: string
-  navn: string
-  manager: string
-  title?: string
-  link: string
-  degree?: string
-  image_key?: string
   email: string
-  customer?: string
-  weight?: number
-  work_order_description?: string
+  name: string
+  title?: string
+  phone?: string
+  degree?: string
+  manager: string
+  image_key?: string
+  link: string
 }
 
 export type BasicEmployeeInformationReport = BasicEmployeeInformation[]
@@ -158,21 +156,14 @@ export type CategoryScores = [
  */
 
 export type EmployeeProfileResponse = Omit<
-  EmployeeWithMergedCustomers,
-  'customer' | 'weight' | 'work_order_description' | 'image_key' | 'link'
+  EmployeeProfileInformation,
+  'guid' | 'image_key' | 'link'
 > & {
   image: string
   workExperience: WorkExperience[]
   tags: Tags
   links: CvLinks
-}
-
-export type EmployeeWithMergedCustomers = EmployeeInformation & {
-  customers: CustomerWithWeight[]
-}
-
-export type CustomerWithWeight = Customer & {
-  weight: number
+  customers: Customer[]
 }
 
 export type Tags = {

--- a/src/api/data/employee/employeeApi.ts
+++ b/src/api/data/employee/employeeApi.ts
@@ -15,7 +15,7 @@ export const getEmployeeTable = () =>
   getAtApiV2<EmployeeTableResponse>('/employees/employeeTable')
 
 export const getEmployeeProfile = (url: string, email: string) =>
-  getAtApi<EmployeeProfileResponse>(`/data/employeeProfile`, {
+  getAtApiV2<EmployeeProfileResponse>(`/employees/employeeProfile`, {
     params: { email },
   })
 

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -51,10 +51,10 @@ export interface CvLinks {
 
 export interface EmployeeExperienceResponse {
   name: string
-  experience?: ProjectExperience[]
+  experience?: EmployeeExperience[]
 }
 
-export interface ProjectExperience {
+export interface EmployeeExperience {
   customer: string
   project: string
   time_to: string
@@ -70,20 +70,28 @@ export interface EmployeeProfileResponse {
   email: string
   name: string
   phone?: string
-  title: string
+  title?: string
   degree?: string
   manager: string
   image?: string
-  workExperience: WorkExperience[]
   tags: Tags
   links: CvLinks
   customers: Customer[]
+  workExperience: WorkExperience[]
+  projectExperience: ProjectExperience[]
 }
 
 export interface WorkExperience {
-  user_id: string
-  email: string
   employer: string
+  month_from: number
+  year_from: number
+  month_to: number
+  year_to: number
+}
+
+export interface ProjectExperience {
+  customer: string
+  project: string
   month_from: number
   year_from: number
   month_to: number

--- a/src/api/data/employee/employeeApiTypes.ts
+++ b/src/api/data/employee/employeeApiTypes.ts
@@ -65,26 +65,19 @@ export interface ProjectExperience {
  * EmployeeProfile
  */
 
-interface Employee {
+export interface EmployeeProfileResponse {
   user_id: string
-  guid: string
-  navn: string
-  manager: string
+  email: string
+  name: string
+  phone?: string
   title: string
   degree?: string
-  email: string
-  customers: CustomerWithWeight[]
-}
-
-export interface EmployeeProfileResponse extends Employee {
+  manager: string
   image?: string
   workExperience: WorkExperience[]
   tags: Tags
   links: CvLinks
-}
-
-export interface CustomerWithWeight extends Customer {
-  weight: number
+  customers: Customer[]
 }
 
 export interface WorkExperience {

--- a/src/components/skeletons/MultiLineSkeleton.tsx
+++ b/src/components/skeletons/MultiLineSkeleton.tsx
@@ -10,14 +10,16 @@ function getLineWidth(index: number) {
 interface MultiLineSkeletonProps {
   lines?: number
   lineHeight?: number | string
+  maxWidth?: number | string
 }
 
 export function MultiLineSkeleton({
   lines = 3,
   lineHeight = '1.5em',
+  maxWidth = '100%',
 }: MultiLineSkeletonProps) {
   return (
-    <>
+    <div style={{ maxWidth }}>
       {Array.from({ length: lines }).map((_, index) => (
         <LineSkeleton
           key={index}
@@ -25,6 +27,6 @@ export function MultiLineSkeleton({
           height={lineHeight}
         />
       ))}
-    </>
+    </div>
   )
 }

--- a/src/pages/employee/components/CustomersForEmployee.tsx
+++ b/src/pages/employee/components/CustomersForEmployee.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { CustomerWithWeight } from '../../../api/data/employee/employeeApiTypes'
+import { Customer } from '../../../api/data/employee/employeeApiTypes'
 import { makeStyles } from '@material-ui/core/styles'
 import { MultiLineSkeleton } from '../../../components/skeletons/MultiLineSkeleton'
 import { FallbackMessage } from './FallbackMessage'
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
 })
 
 interface Props {
-  customers?: CustomerWithWeight[]
+  customers?: Customer[]
   isLoading?: boolean
   isError?: boolean
 }
@@ -35,14 +35,16 @@ export function CustomersForEmployee({ customers, isLoading, isError }: Props) {
     return <FallbackMessage message="Fant ingen kunder å vise." />
   }
 
-  const customersSortedByWeight = customers.sort(
-    (customerA, customerB) => customerA.weight - customerB.weight
+  const sortedCustomers = customers.sort((customerA, customerB) =>
+    String(customerA.customer).localeCompare(String(customerB.customer))
   )
 
   return (
     <ExperienceList>
-      {customersSortedByWeight.map((customer) => (
-        <ExperienceListItem key={customer.customer + customer.weight}>
+      {sortedCustomers.map((customer) => (
+        <ExperienceListItem
+          key={customer.customer + customer.workOrderDescription}
+        >
           <span className={classes.customerName}>{customer.customer}: </span>
           {customer.workOrderDescription}
         </ExperienceListItem>

--- a/src/pages/employee/components/EmployeeByline.tsx
+++ b/src/pages/employee/components/EmployeeByline.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react'
 import { makeStyles } from '@material-ui/core'
 import { LineSkeleton } from '../../../components/skeletons/LineSkeleton'
+import { EmployeeProfileResponse } from '../../../api/data/employee/employeeApiTypes'
+import { MultiLineSkeleton } from '../../../components/skeletons/MultiLineSkeleton'
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   name: {
     fontSize: '2rem',
     margin: '15px 0',
@@ -10,37 +12,68 @@ const useStyles = makeStyles({
   jobTitle: {
     fontWeight: 'bold',
     fontSize: '1.5rem',
-    margin: '15px 0',
+    margin: '0',
   },
-})
+  contactInfo: {
+    margin: '0',
+    marginTop: '10px',
+    lineHeight: '1.5rem',
+    '& dt, dd': { display: 'inline', margin: 0 },
+  },
+  link: {
+    color: theme.palette.text.primary,
+  },
+}))
 
 interface Props {
-  employeeName?: string
-  jobTitle?: string
+  employee?: EmployeeProfileResponse
   isLoading?: boolean
 }
 
-export function EmployeeByline({ employeeName, jobTitle, isLoading }: Props) {
+export function EmployeeByline({ employee, isLoading }: Props) {
   const classes = useStyles()
 
   const EmployeeName = () =>
     isLoading ? (
       <LineSkeleton width="50%" height="3em" />
     ) : (
-      <h1 className={classes.name}>{employeeName}</h1>
+      <h1 className={classes.name}>{employee?.name}</h1>
     )
 
   const EmployeeJobTitle = () =>
     isLoading ? (
-      <LineSkeleton width="40%" height="2em" />
+      <LineSkeleton width="40%" height="1.5em" />
     ) : (
-      <p className={classes.jobTitle}>{jobTitle}</p>
+      <p className={classes.jobTitle}>{employee?.title}</p>
+    )
+
+  const EmployeeContactInfo = () =>
+    isLoading ? (
+      <MultiLineSkeleton lines={2} maxWidth="45%" lineHeight="1.5em" />
+    ) : (
+      <dl className={classes.contactInfo}>
+        <div>
+          <dt>E-post: </dt>
+          <dd>
+            <a className={classes.link} href={`mailto:${employee?.email}`}>
+              {employee?.email}
+            </a>
+          </dd>
+        </div>
+        {employee?.phone ? (
+          <div>
+            <dt>Telefon: </dt>
+            <dd>{employee?.phone}</dd>
+          </div>
+        ) : null}
+      </dl>
     )
 
   return (
     <div>
       <EmployeeName />
       <EmployeeJobTitle />
+      <EmployeeContactInfo />
     </div>
   )
 }

--- a/src/pages/employee/components/EmployeeByline.tsx
+++ b/src/pages/employee/components/EmployeeByline.tsx
@@ -33,27 +33,31 @@ interface Props {
 export function EmployeeByline({ employee, isLoading }: Props) {
   const classes = useStyles()
 
-  const EmployeeName = () =>
-    isLoading ? (
-      <LineSkeleton width="50%" height="3em" />
-    ) : (
-      <h1 className={classes.name}>{employee?.name}</h1>
-    )
+  const EmployeeName = () => {
+    if (isLoading) {
+      return <LineSkeleton width="50%" height="3em" />
+    }
+    return <h1 className={classes.name}>{employee?.name}</h1>
+  }
 
-  const EmployeeJobTitle = () =>
-    isLoading ? (
-      <LineSkeleton width="40%" height="1.5em" />
-    ) : (
-      <p className={classes.jobTitle}>{employee?.title}</p>
-    )
+  const EmployeeJobTitle = () => {
+    if (isLoading) {
+      return <LineSkeleton width="40%" height="1.5em" />
+    }
+    if (employee?.title) {
+      return <p className={classes.jobTitle}>{employee?.title}</p>
+    }
+    return null
+  }
 
-  const EmployeeContactInfo = () =>
-    isLoading ? (
-      <MultiLineSkeleton lines={2} maxWidth="45%" lineHeight="1.5em" />
-    ) : (
+  const EmployeeContactInfo = () => {
+    if (isLoading) {
+      return <MultiLineSkeleton lines={2} maxWidth="45%" lineHeight="1.5em" />
+    }
+    return (
       <dl className={classes.contactInfo}>
         <div>
-          <dt>E-post: </dt>
+          <dt>E-post:</dt>
           <dd>
             <a className={classes.link} href={`mailto:${employee?.email}`}>
               {employee?.email}
@@ -62,12 +66,13 @@ export function EmployeeByline({ employee, isLoading }: Props) {
         </div>
         {employee?.phone ? (
           <div>
-            <dt>Telefon: </dt>
+            <dt>Telefon:</dt>
             <dd>{employee?.phone}</dd>
           </div>
         ) : null}
       </dl>
     )
+  }
 
   return (
     <div>

--- a/src/pages/employee/components/EmployeeByline.tsx
+++ b/src/pages/employee/components/EmployeeByline.tsx
@@ -57,7 +57,7 @@ export function EmployeeByline({ employee, isLoading }: Props) {
     return (
       <dl className={classes.contactInfo}>
         <div>
-          <dt>E-post:</dt>
+          <dt>E-post:&nbsp;</dt>
           <dd>
             <a className={classes.link} href={`mailto:${employee?.email}`}>
               {employee?.email}
@@ -66,7 +66,7 @@ export function EmployeeByline({ employee, isLoading }: Props) {
         </div>
         {employee?.phone ? (
           <div>
-            <dt>Telefon:</dt>
+            <dt>Telefon:&nbsp;</dt>
             <dd>{employee?.phone}</dd>
           </div>
         ) : null}

--- a/src/pages/employee/components/EmployeeInfo.tsx
+++ b/src/pages/employee/components/EmployeeInfo.tsx
@@ -9,7 +9,7 @@ import { formatMonthYearRange } from '../../../utils/formatMonthYearRange'
 import {
   ConsultantInfo,
   EmployeeExperienceResponse,
-  ProjectExperience,
+  EmployeeExperience,
   WorkExperience,
 } from '../../../api/data/employee/employeeApiTypes'
 import { getStartedInKnowit } from '../../../utils/getStartedInKnowit'
@@ -284,8 +284,8 @@ export const GetProjects = (expData: {
 }
 
 function compareProjectDates(
-  projectA: ProjectExperience,
-  projectB: ProjectExperience
+  projectA: EmployeeExperience,
+  projectB: EmployeeExperience
 ) {
   const aDate = new Date(projectA.time_from || projectA.time_to)
   const bDate = new Date(projectB.time_from || projectB.time_to)

--- a/src/pages/employee/components/EmployeeProfileContent.tsx
+++ b/src/pages/employee/components/EmployeeProfileContent.tsx
@@ -82,7 +82,7 @@ export function EmployeeProfileContent({ employeeEmail }: Props) {
             <CompetenceSummary employee={employee} isLoading={isLoading} />
           </section>
           <section>
-            <h2>Kunder</h2>
+            <h2>Kunder siste måned</h2>
             <CustomersForEmployee
               customers={employee?.customers}
               isLoading={isLoading}
@@ -97,7 +97,10 @@ export function EmployeeProfileContent({ employeeEmail }: Props) {
           </section>
           <section>
             <h2>Prosjekterfaring</h2>
-            <ProjectExperienceList user_id={employee?.user_id} />
+            <ProjectExperienceList
+              projectExperience={employee?.projectExperience}
+              isLoading={isLoading}
+            />
           </section>
           <section>
             <h2>Last ned CV</h2>

--- a/src/pages/employee/components/EmployeeProfileContent.tsx
+++ b/src/pages/employee/components/EmployeeProfileContent.tsx
@@ -74,11 +74,7 @@ export function EmployeeProfileContent({ employeeEmail }: Props) {
     <article className={classes.root}>
       <div className={classes.header}>
         <EmployeeAvatar imageUrl={employee?.image} isLoading={isLoading} />
-        <EmployeeByline
-          employeeName={employee?.navn}
-          jobTitle={employee?.title}
-          isLoading={isLoading}
-        />
+        <EmployeeByline employee={employee} isLoading={isLoading} />
       </div>
       <div className={classes.body}>
         <div className={classes.column}>

--- a/src/utils/formatMonthYear.ts
+++ b/src/utils/formatMonthYear.ts
@@ -14,10 +14,10 @@ const months = [
 ]
 
 export function formatMonthYear(
-  month: number | undefined,
+  month: number,
   year: number
 ): string | undefined {
-  if (year === -1) {
+  if (!year || year <= 0) {
     return
   }
   if (!month || month <= 0) {

--- a/src/utils/formatMonthYearRange.ts
+++ b/src/utils/formatMonthYearRange.ts
@@ -1,9 +1,9 @@
 import { formatMonthYear } from './formatMonthYear'
 
 export function formatMonthYearRange(
-  fromMonth: number | undefined,
+  fromMonth: number,
   fromYear: number,
-  toMonth: number | undefined,
+  toMonth: number,
   toYear: number
 ): string {
   return [


### PR DESCRIPTION
* Migrated frontend to API **v2** for the `employeeProfile` endpoint.
* Added new report `employeeProfileInformation` that does not contain customer information. 
  * Replaced data from `employeeInformation` report with data from this new report in combination with the `employeeCustomers` report. This removed the need for the `mergeCustomersForEmployees` function entirely. 
  * This also fixed a problem with duplicate customers being listed on the employee profile page.
* Added `email` as a field in `projectExperience` report, allowing us to use this in stead of `user_id` to look up data for an employee (which is how it's done almost everywhere else).
* Included project experience into the response data from the `employeeProfile` endpoint, and utilized this on the employee profile page.
* Added email and phone information on the employee profile page.
* Removed deprecated code from API **v1** (`data.ts` and `util.ts`)