### PR TITLE
Periode filter på kundesiden/overordnet oversikt

### DIFF
--- a/apps/web/src/components/charts/SingularChartCard.tsx
+++ b/apps/web/src/components/charts/SingularChartCard.tsx
@@ -48,7 +48,7 @@ function getWeek(fromDate?: Date): number {
 }
 
 /** Returns number of first week of current quarter */
-const getWeekOfQuarter = () => {
+function getWeekOfQuarter() {
   const currDate = overrideDate || new Date()
   const quarter = Math.ceil(currDate.getMonth() / 3) - 1
   const month = [0, 3, 6, 9][quarter]
@@ -57,14 +57,14 @@ const getWeekOfQuarter = () => {
 }
 
 /** Returns number of first week of current month */
-const getWeekOfMonth = () => {
+function getWeekOfMonth() {
   const currDate = overrideDate || new Date()
 
   return getWeek(new Date(currDate.getFullYear(), currDate.getMonth(), 1))
 }
 
 /** Returns a list of sequential reg periods (year + week number), starting from @fromWeek to current reg period */
-const getRegPeriodsFromWeek = (fromWeek: number): string[] => {
+function getRegPeriodsFromWeek(fromWeek: number): string[] {
   const currDate = overrideDate || new Date()
   const currYear = currDate.getFullYear()
   const currWeek = getWeek()

--- a/apps/web/src/components/charts/SingularChartCard.tsx
+++ b/apps/web/src/components/charts/SingularChartCard.tsx
@@ -17,6 +17,80 @@ interface SingularChartCardProps {
   showFilter?: boolean
 }
 
+type FilterOptions =
+  | 'Siste uke'
+  | 'Siste måned'
+  | 'Siste kvartal'
+  | 'Hittil i år'
+  | 'Totalt'
+
+// Can be used to override date to set an older date, for testing purposes
+const overrideDate = new Date(2021, 10, 13)
+
+/** Returns the ISO week of current date or from optional param @fromDate */
+function getWeek(fromDate?: Date): number {
+  const weekDate = new Date(fromDate ? fromDate : overrideDate || new Date())
+  weekDate.setHours(0, 0, 0, 0)
+  // Thursday in current week decides the year
+  weekDate.setDate(weekDate.getDate() + 3 - ((weekDate.getDay() + 6) % 7))
+  // January 4 is always in week 1
+  const firstWeek = new Date(weekDate.getFullYear(), 0, 4)
+  // Adjust to Thursday in week 1 and count number of weeks from date to week 1
+  return (
+    1 +
+    Math.round(
+      ((weekDate.getTime() - firstWeek.getTime()) / 86400000 -
+        3 +
+        ((firstWeek.getDay() + 6) % 7)) /
+        7
+    )
+  )
+}
+
+/** Returns number of first week of current quarter */
+const getWeekOfQuarter = () => {
+  const currDate = overrideDate || new Date()
+  const quarter = Math.ceil(currDate.getMonth() / 3) - 1
+  const month = [0, 3, 6, 9][quarter]
+
+  return getWeek(new Date(currDate.getFullYear(), month, 1))
+}
+
+/** Returns number of first week of current month */
+const getWeekOfMonth = () => {
+  const currDate = overrideDate || new Date()
+
+  return getWeek(new Date(currDate.getFullYear(), currDate.getMonth(), 1))
+}
+
+/** Returns a list of sequential reg periods (year + week number), starting from @fromWeek to current reg period */
+const getRegPeriodsFromWeek = (fromWeek: number): string[] => {
+  const currDate = overrideDate || new Date()
+  const currYear = currDate.getFullYear()
+  const currWeek = getWeek()
+  const length = currWeek - fromWeek + 1
+  const weekDates = length
+    ? [...new Array(length)].map((_, i) => `${currYear}${fromWeek + i}`)
+    : []
+
+  return weekDates
+}
+
+function getRegPeriods(filter: FilterOptions) {
+  switch (filter) {
+    case 'Siste uke':
+      return getRegPeriodsFromWeek(getWeek())
+    case 'Siste måned':
+      return getRegPeriodsFromWeek(getWeekOfMonth())
+    case 'Siste kvartal':
+      return getRegPeriodsFromWeek(getWeekOfQuarter())
+    case 'Hittil i år':
+      return getRegPeriodsFromWeek(1)
+    default:
+      return getRegPeriodsFromWeek(getWeek())
+  }
+}
+
 /**
  * A card for rendering a single card.
  */
@@ -28,27 +102,23 @@ const SingularChartCard = ({
   data,
 }: SingularChartCardProps) => {
   const [isBig, setIsBig] = useState(false)
-  const filterValues = ['Siste måned', 'Siste kvartal', 'Hittil i år', 'Totalt']
+  const filterValues: FilterOptions[] = [
+    'Siste uke',
+    'Siste måned',
+    'Siste kvartal',
+    'Hittil i år',
+    'Totalt',
+  ]
   const [selectedFilter, setSelectedFilter] = useState(filterValues[0])
 
-  function getFilterData(filter: string): SingularChartData {
+  function getFilterData(filter: FilterOptions): SingularChartData {
     if (
       (data && data.type === 'LineChart') ||
       (data && data.type === 'BarChart')
     ) {
-      //To be used with getCurrentRegPeriod() to generate list of regPeriods.
-      switch (filter) {
-        case 'Siste måned':
-          return findFilteredData(['202143', '202144', '202145', '202146'])
-        case 'Siste kvartal':
-          return findFilteredData(['202143', '202144', '202146'])
-        case 'Hittil i år':
-          return findFilteredData()
-        case 'Totalt':
-          return findFilteredData()
-        default:
-          return findFilteredData()
-      }
+      return filter === 'Totalt'
+        ? data
+        : findFilteredData(getRegPeriods(filter))
     } else {
       return data
     }
@@ -122,31 +192,6 @@ const SingularChartCard = ({
       return data
     }
   }
-
-  /* function getYear(){
-    const currentDate = new Date()
-    const currentYear = currentDate.getFullYear()
-    return currentYear
-  }
-
-  function getWeek(){
-    const currentDate = new Date()
-    const oneJan = new Date(getYear(), 0, 1)
-    const numberOfDays = Math.floor(
-      (Number(currentDate) - Number(oneJan)) / (24 * 60 * 60 * 1000)
-    )
-    const currentWeekNumber = Math.ceil(
-      (currentDate.getDay() + 1 + numberOfDays) / 7
-    )
-    return currentWeekNumber.toString()
-  }
-
-  function getCurrentRegPeriod(){
-    const currYear = getYear()
-    const currWeek = getWeek()
-    const regPeriod: string = currYear + currWeek
-    return regPeriod
-  }*/
 
   return (
     <GridItem fullSize={fullSize}>

--- a/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
@@ -12,7 +12,7 @@ const HoursBilledPerCustomerCard = () => {
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}
-      showFilter={false}
+      showFilter={true}
     />
   )
 }

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -8,7 +8,7 @@ const HoursBilledPerWeekCard = () => {
 
   return (
     <ChartCard
-      title="Timer brukt per periode"
+      title="Timer brukt per uke"
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -12,7 +12,7 @@ const HoursBilledPerWeekCard = () => {
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}
-      showFilter={true}
+      showFilter={false}
     />
   )
 }

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -8,11 +8,11 @@ const HoursBilledPerWeekCard = () => {
 
   return (
     <ChartCard
-      title="Timer brukt per uke"
+      title="Timer brukt per periode"
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}
-      showFilter={false}
+      showFilter={true}
     />
   )
 }


### PR DESCRIPTION
PR for [#702](https://github.com/knowit/Dataplattform-issues/issues/702) og en videreføring (duplikat?) av [#657](https://github.com/knowit/Dataplattform-issues/issues/657) for å filtrere på perioder på kundesiden.

Implementasjonen innebærer å servere `findFilteredData` med riktig liste av reg_periods, basert på valgt filter.
F.eks hvis dagens dato er 19. november 2021, og '_Siste måned_' er valgt, filtreres dataen fra første uke i november -> `['202144', '202145', '202146']`

- [x] Kunne vise siste måneds-oversikt over timer per kunde.
- [x] Kunne velge ulike perioder.
- [ ] Dagens oversikt kan være et av valgene
- [ ] "i" knappen er synkron med de data som er vist - også når periode byttes.

**NB**: Per nå brukes `overrideDate` i `SingularChartCard` for å definere spesifikk dato slik at perioder med dev data gir mening (13. November 2021). Denne må fjernes før pull til master, evnt bør vi få inn noe mer gjeldende dev data.
