### PR TITLE
Feature/Timer brukt per uke filter

### DIFF
--- a/apps/web/src/components/charts/ChartCard.tsx
+++ b/apps/web/src/components/charts/ChartCard.tsx
@@ -13,6 +13,7 @@ import RadarChart from './nivo/RadarChart'
 import SunburstChart from './nivo/SunburstChart'
 import MultipleChartCard from './MultipleChartCard'
 import SingularChartCard from './SingularChartCard'
+import { ChartFilterType } from './chartFilters/useFilteredData'
 
 interface SingularChartProps {
   chartData: SingularChartData
@@ -46,6 +47,7 @@ interface ChartCardProps {
   data: ChartData | undefined
   error: any
   showFilter?: boolean
+  filterType?: ChartFilterType
 }
 
 const ChartCard = ({
@@ -53,6 +55,7 @@ const ChartCard = ({
   data,
   error,
   title,
+  filterType,
   showFilter = false,
   ...props
 }: ChartCardProps) => {
@@ -80,6 +83,7 @@ const ChartCard = ({
       title={title}
       data={data}
       showFilter={showFilter}
+      filterType={filterType}
       {...props}
     />
   )

--- a/apps/web/src/components/charts/chartFilters/useFilteredData.ts
+++ b/apps/web/src/components/charts/chartFilters/useFilteredData.ts
@@ -1,0 +1,42 @@
+import { SingularChartData } from '../../../../../../packages/folk-common/types/chartTypes'
+import usePerWeekFilter, { PerWeekFilterOptions } from './usePerWeekFilter'
+import perCustomerFilter, {
+  PerCustomerFilterOptions,
+} from './usePerCustomerFilter'
+import { Dispatch, SetStateAction } from 'react'
+
+export type ChartFilterType = 'perWeek' | 'perCustomer'
+
+type FilterOption = PerCustomerFilterOptions | PerWeekFilterOptions
+
+export type FilteredData = {
+  filterOptions: FilterOption[]
+  selectedFilter: FilterOption
+  setSelectedFilter: Dispatch<SetStateAction<FilterOption>>
+  getFilteredData: () => SingularChartData
+}
+
+const getHook = (type: ChartFilterType) => {
+  switch (type) {
+    case 'perWeek':
+      return usePerWeekFilter
+    case 'perCustomer':
+      return perCustomerFilter
+    default:
+      return usePerWeekFilter
+  }
+}
+
+const useFilteredData = (
+  type: ChartFilterType,
+  data: SingularChartData
+): FilteredData => {
+  const hook = getHook(type)
+
+  const { filterOptions, selectedFilter, setSelectedFilter, getFilteredData } =
+    hook(data)
+
+  return { filterOptions, getFilteredData, selectedFilter, setSelectedFilter }
+}
+
+export default useFilteredData

--- a/apps/web/src/components/charts/chartFilters/usePerCustomerFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerCustomerFilter.ts
@@ -1,0 +1,133 @@
+import { SingularChartData } from '../../../../../../packages/folk-common/types/chartTypes'
+import { useState } from 'react'
+import { FilteredData } from './useFilteredData'
+
+export type PerCustomerFilterOptions =
+  | 'Siste uke'
+  | 'Siste måned'
+  | 'Siste kvartal'
+  | 'Hittil i år'
+  | 'Totalt'
+
+// Can be used to override date to set an older date, for testing purposes
+const overrideDate = new Date(2021, 10, 13)
+
+/** Returns the ISO week of current date or from optional param @fromDate */
+function getWeek(fromDate?: Date): number {
+  const weekDate = new Date(fromDate ? fromDate : overrideDate || new Date())
+  weekDate.setHours(0, 0, 0, 0)
+  // Thursday in current week decides the year
+  weekDate.setDate(weekDate.getDate() + 3 - ((weekDate.getDay() + 6) % 7))
+  // January 4 is always in week 1
+  const firstWeek = new Date(weekDate.getFullYear(), 0, 4)
+  // Adjust to Thursday in week 1 and count number of weeks from date to week 1
+  return (
+    1 +
+    Math.round(
+      ((weekDate.getTime() - firstWeek.getTime()) / 86400000 -
+        3 +
+        ((firstWeek.getDay() + 6) % 7)) /
+        7
+    )
+  )
+}
+
+/** Returns number of first week of current quarter */
+function getWeekOfQuarter(): number {
+  const currDate = overrideDate || new Date()
+  const quarter = Math.ceil(currDate.getMonth() / 3) - 1
+  const month = [0, 3, 6, 9][quarter]
+
+  return getWeek(new Date(currDate.getFullYear(), month, 1))
+}
+
+/** Returns number of first week of current month */
+function getWeekOfMonth(): number {
+  const currDate = overrideDate || new Date()
+
+  return getWeek(new Date(currDate.getFullYear(), currDate.getMonth(), 1))
+}
+
+/** Returns a list of sequential reg periods (year + week number), starting from @fromWeek to current reg period */
+function getRegPeriodsFromWeek(fromWeek: number): string[] {
+  const currDate = overrideDate || new Date()
+  const currYear = currDate.getFullYear()
+  const currWeek = getWeek()
+  const length = currWeek - fromWeek + 1
+  const weekDates = length
+    ? [...new Array(length)].map((_, i) => `${currYear}${fromWeek + i}`)
+    : []
+
+  return weekDates
+}
+
+function getRegPeriods(filter: PerCustomerFilterOptions): string[] {
+  switch (filter) {
+    case 'Siste måned':
+      return getRegPeriodsFromWeek(getWeekOfMonth())
+    case 'Siste kvartal':
+      return getRegPeriodsFromWeek(getWeekOfQuarter())
+    case 'Hittil i år':
+      return getRegPeriodsFromWeek(1)
+    default:
+      return getRegPeriodsFromWeek(getWeek())
+  }
+}
+
+const usePerCustomerFilter = (data: SingularChartData): FilteredData => {
+  const filterOptions: PerCustomerFilterOptions[] = [
+    'Siste uke',
+    'Siste måned',
+    'Siste kvartal',
+    'Hittil i år',
+    'Totalt',
+  ]
+
+  const [selectedFilter, setSelectedFilter] = useState(filterOptions[0])
+
+  const getFilteredData = (): SingularChartData => {
+    const regPeriods = getRegPeriods(selectedFilter)
+
+    if (regPeriods === undefined || regPeriods.length === 0) return data
+
+    if (data && data.type === 'BarChart' && selectedFilter !== 'Totalt') {
+      const aggregatedData: { customer: string; hours: number }[] = []
+
+      data.data.forEach((customer) => {
+        if (aggregatedData.indexOf(customer) < 0) {
+          aggregatedData.push({ customer: customer.customer, hours: 0 })
+          if (data.weeklyData) {
+            const currentCustomer = data.weeklyData.data.find(
+              (item) => item.id === customer.customer
+            )
+            currentCustomer?.data.forEach((regPeriod) => {
+              if (regPeriods.includes(regPeriod.x)) {
+                const customerIndex = aggregatedData.findIndex(
+                  (c) => c.customer === currentCustomer.id
+                )
+                aggregatedData[customerIndex].hours += regPeriod.y
+              }
+            })
+          }
+        }
+      })
+
+      const filteredData = aggregatedData
+        .filter((customer) => customer.hours !== 0)
+        .sort((a, b) => (a.hours < b.hours ? 1 : -1))
+
+      return {
+        type: data.type,
+        indexBy: data.indexBy,
+        keys: data.keys,
+        data: filteredData,
+      }
+    } else {
+      return data
+    }
+  }
+
+  return { filterOptions, selectedFilter, setSelectedFilter, getFilteredData }
+}
+
+export default usePerCustomerFilter

--- a/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
@@ -1,0 +1,97 @@
+import { SingularChartData } from '../../../../../../packages/folk-common/types/chartTypes'
+import { useState } from 'react'
+import { FilteredData } from './useFilteredData'
+
+export type PerWeekFilterOptions = 'Uke' | 'Måned' | 'Kvartal' | 'År'
+
+type DateDisplay = {
+  month: string
+  year: string
+  week: string
+  quarter: string
+  date: Date
+}
+
+function getDateDisplay(regPeriod: string): DateDisplay {
+  const y = Number(regPeriod.slice(0, 4))
+  const w = Number(regPeriod.slice(-2))
+  const date = new Date(y, 0, 1 + (w - 1) * 7)
+  date.setDate(date.getDate() + (1 - date.getDay()))
+
+  const month = date.toLocaleString('no-NO', { month: 'short' })
+  const quarter = Math.ceil(date.getMonth() / 3) - 1
+
+  return {
+    month: `${y} - ${month}`,
+    year: `${y}`,
+    week: `${y} - Uke ${w}`,
+    quarter: `${y} - Q${quarter}`,
+    date: date,
+  }
+}
+
+const usePerWeekFilter = (data: SingularChartData): FilteredData => {
+  const filterOptions: PerWeekFilterOptions[] = [
+    'Uke',
+    'Måned',
+    'Kvartal',
+    'År',
+  ]
+
+  const [selectedFilter, setSelectedFilter] = useState(filterOptions[0])
+
+  const getFilteredData = (): SingularChartData => {
+    if (data && data.type === 'LineChart') {
+      const filteredData = data.data.map((customer) => {
+        const filteredData = customer.data
+          .map((v) => {
+            const date = getDateDisplay(v.x)
+            const value = { ...v, date: date.date }
+
+            switch (selectedFilter) {
+              case 'Uke':
+                return { ...value, x: date.week }
+              case 'Måned':
+                return { ...value, x: date.month }
+              case 'Kvartal':
+                return { ...value, x: date.quarter }
+              case 'År':
+                return { ...value, x: date.year }
+              default:
+                return value
+            }
+          })
+          .reduce((list, value) => {
+            const sum = list
+              .filter((o) => o.x === value.x)
+              .reduce((v, o) => o.y + v, 0)
+
+            return [
+              ...list.filter((o) => o.x !== value.x),
+              { ...value, y: sum + value.y },
+            ]
+          }, [])
+          .sort((a, b) => a.date - b.date)
+
+        // Filter out empty data
+        return filteredData.length
+          ? {
+              ...customer,
+              data: filteredData,
+            }
+          : null
+      })
+
+      return {
+        ...data,
+        data: filteredData,
+      }
+    } else {
+      return data
+    }
+  }
+
+  return { filterOptions, selectedFilter, setSelectedFilter, getFilteredData }
+}
+
+export default usePerWeekFilter

--- a/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
@@ -12,6 +12,7 @@ type DateDisplay = {
   date: Date
 }
 
+/** Returns props of x scale displays and date based on regPeriod to compare sort */
 function getDateDisplay(regPeriod: string): DateDisplay {
   const y = Number(regPeriod.slice(0, 4))
   const w = Number(regPeriod.slice(-2))

--- a/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
@@ -13,6 +13,7 @@ const HoursBilledPerCustomerCard = () => {
       data={data}
       error={error}
       showFilter={true}
+      filterType="perCustomer"
     />
   )
 }

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -8,7 +8,7 @@ const HoursBilledPerWeekCard = () => {
 
   return (
     <ChartCard
-      title="Timer brukt per uke"
+      title="Timer brukt per periode"
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -12,7 +12,8 @@ const HoursBilledPerWeekCard = () => {
       description={POSSIBLE_OLD_DATA_WARNING}
       data={data}
       error={error}
-      showFilter={false}
+      showFilter={true}
+      filterType="perWeek"
     />
   )
 }


### PR DESCRIPTION
PR på [#701](https://github.com/knowit/Dataplattform-issues/issues/701), videreføring av [#657](https://github.com/knowit/Dataplattform-issues/issues/657).

Filter data hentes nå via hook (`charts/chartFilters/useFilteredData`). SingularChartCard har en ny prop `filterType` som velger type av filter som skal vises.  

Et lite problem jeg ikke fant ut er hvordan nivo charts sorterer x-linjen:
![image](https://user-images.githubusercontent.com/12533245/209084190-e7f5a0f6-b671-4eea-bfd7-053f35865f5a.png)

Nivo charts gjør noe internt for å sortere charts med  `xScale={{ type: 'point' }}`. Fant lite dokumentasjon på dette.