### PR TITLE
Fikse internal server error for prod grunnet undefined liste

### DIFF
--- a/apps/server/routers/customer/customerAggregation.ts
+++ b/apps/server/routers/customer/customerAggregation.ts
@@ -86,9 +86,10 @@ export function createCustomerCardData(
     const consultants = new Set()
     employeesCustomer.forEach((employeeCustomer) => {
       if (employeeCustomer.customer == customer) {
-        const reg_periods = employeeCustomer.reg_periods
-          .split(';')
-          .map((period) => Number(period))
+        const reg_periods =
+          employeeCustomer?.reg_periods
+            .split(';')
+            .map((period) => Number(period)) || []
         if (last_reg_periods.some((p) => reg_periods.includes(p))) {
           consultants.add(employeeCustomer.user_id)
         }


### PR DESCRIPTION
Plutselig dukket det opp internal server error i prod. I Cloudwatch står det : `employeeCustomer.reg_periods.split is not a function`
Vi antar at det av en eller annen grunn da er kommet inn en tom liste som den ikke klarer å ta split på, så da legger vi ved sjekk for dette