### PR TITLE
Gjøre organisasjons-side utilgjengelig inntil videre

### DIFF
--- a/apps/web/src/components/Content.tsx
+++ b/apps/web/src/components/Content.tsx
@@ -28,7 +28,7 @@ export default function Content() {
       <Route path="/ansatt/:id" element={<EmployeeProfilePage />} />
       <Route path="/kunder" element={<CustomerPage />} />
       <Route path="/kompetanse" element={<CompetencePage />} />
-      <Route path="/organisasjon" element={<OrganizationStructurePage />} />
+      <Route path="/organisasjon" element={<UnderConstructionPage />} />
       <Route path="/arbeidsmiljo" element={<UnderConstructionPage />} />
       <Route path="/rekruttering" element={<UnderConstructionPage />} />
       <Route path="/debug" element={<DebugPage />} />

--- a/apps/web/src/components/Content.tsx
+++ b/apps/web/src/components/Content.tsx
@@ -10,7 +10,6 @@ import {
   NotFoundPage,
   UnderConstructionPage,
   DebugPage,
-  OrganizationStructurePage,
 } from '../pages'
 import LoginPage from '../pages/login/LoginPage'
 


### PR DESCRIPTION
Grunnet mangel på data så gjør vi siden utilgjengelig frem til den er tilstrekkelig testet med data fra prod. For øyeblikket så får ikke strukturen plass i bildet, så her må det testes videre lokalt først