### PR TITLE
Fiks usortert x-akse på "Timer brukt per periode" grafen

### DIFF
--- a/apps/server/routers/customer/customerChartConversion.ts
+++ b/apps/server/routers/customer/customerChartConversion.ts
@@ -5,6 +5,7 @@ function getHoursBilledPerWeek(
   data: BilledCustomerHours[]
 ): LineChartData['data'] {
   const aggregationMap: Record<string, Record<string, number>> = {}
+  const regPeriodsSet = new Set()
 
   // Build map of customers and aggregate all hours for all weeks
   for (const { customer, reg_period, hours } of data) {
@@ -17,15 +18,29 @@ function getHoursBilledPerWeek(
     } else {
       aggregationMap[customer][reg_period] += hours
     }
+
+    regPeriodsSet.add(reg_period)
   }
 
+  const sortedRegPeriods = Array.from(regPeriodsSet).sort()
   const output: LineChartData['data'] = []
+
   // Generate output fitting desired format
   for (const [customer, values] of Object.entries(aggregationMap)) {
+    // Ensure that all weeks are present in the data even if there are no hours billed
+    sortedRegPeriods.forEach((regPeriod: string) => {
+      if (!(regPeriod in values)) {
+        values[regPeriod] = 0
+      }
+    })
+
     const dataList = []
     for (const [x, y] of Object.entries(values)) {
       dataList.push({ x, y })
     }
+
+    dataList.sort((a, b) => parseInt(a.x) - parseInt(b.x))
+
     output.push({ id: customer, data: dataList })
   }
   return output

--- a/apps/web/src/components/charts/ChartCard.tsx
+++ b/apps/web/src/components/charts/ChartCard.tsx
@@ -14,6 +14,7 @@ import SunburstChart from './nivo/SunburstChart'
 import MultipleChartCard from './MultipleChartCard'
 import SingularChartCard from './SingularChartCard'
 import { ChartFilterType } from './chartFilters/useFilteredData'
+import { SliceTooltip } from '@nivo/line'
 
 interface SingularChartProps {
   chartData: SingularChartData
@@ -25,6 +26,7 @@ interface SingularChartProps {
 export const SingularChart = ({
   isBig,
   chartData,
+  ...props
 }: SingularChartProps & IsBigProps) => {
   switch (chartData.type) {
     case 'BarChart':
@@ -32,7 +34,7 @@ export const SingularChart = ({
     case 'RadarChart':
       return <RadarChart isBig={isBig} {...chartData} />
     case 'LineChart':
-      return <LineChart isBig={isBig} {...chartData} />
+      return <LineChart isBig={isBig} {...chartData} {...props} />
     case 'PieChart':
       return <PieChart isBig={isBig} {...chartData} />
     case 'SunburstChart':
@@ -48,6 +50,7 @@ interface ChartCardProps {
   error: any
   showFilter?: boolean
   filterType?: ChartFilterType
+  sliceTooltip?: SliceTooltip
 }
 
 const ChartCard = ({

--- a/apps/web/src/components/charts/SingularChartCard.tsx
+++ b/apps/web/src/components/charts/SingularChartCard.tsx
@@ -11,6 +11,7 @@ import { SingularChart } from './ChartCard'
 import useFilteredData, {
   ChartFilterType,
 } from './chartFilters/useFilteredData'
+import { SliceTooltip } from '@nivo/line'
 
 interface SingularChartCardProps {
   title: string
@@ -19,6 +20,7 @@ interface SingularChartCardProps {
   data: SingularChartData
   showFilter?: boolean
   filterType?: ChartFilterType
+  sliceTooltip?: SliceTooltip
 }
 
 /**
@@ -31,6 +33,7 @@ const SingularChartCard = ({
   showFilter,
   filterType,
   data,
+  ...props
 }: SingularChartCardProps) => {
   const [isBig, setIsBig] = useState(false)
   const { filterOptions, getFilteredData, setSelectedFilter, selectedFilter } =
@@ -55,11 +58,11 @@ const SingularChartCard = ({
         </ChartDisplayOptions>
 
         {/* The small chart */}
-        <SingularChart isBig={false} chartData={chartData} />
+        <SingularChart isBig={false} chartData={chartData} {...props} />
 
         {/* The big chart */}
         <BigChart open={isBig} onClose={() => setIsBig(false)}>
-          <SingularChart isBig={isBig} chartData={chartData} />
+          <SingularChart isBig={isBig} chartData={chartData} {...props} />
         </BigChart>
       </GridItemContent>
     </GridItem>

--- a/apps/web/src/components/charts/nivo/LineChart.tsx
+++ b/apps/web/src/components/charts/nivo/LineChart.tsx
@@ -8,7 +8,7 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
 }) => (
   <div style={{ width: '100%', height: isBig ? '400px' : '280px' }}>
     <ResponsiveLine
-      margin={{ top: 10, right: 20, bottom: 70, left: 40 }}
+      margin={{ top: 10, right: 40, bottom: 70, left: 40 }}
       animate={false}
       xScale={{ type: 'point' }}
       yScale={{

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ChartCard from '../../../components/charts/ChartCard'
 import { useHoursBilledPerWeekCharts } from '../../../api/data/customer/customerQueries'
 import { POSSIBLE_OLD_DATA_WARNING } from './messages'
+import HoursBilledPerWeekTooltip from '../components/HoursBilledPerWeekTooltip'
 
 const HoursBilledPerWeekCard = () => {
   const { data, error } = useHoursBilledPerWeekCharts()
@@ -14,6 +15,7 @@ const HoursBilledPerWeekCard = () => {
       error={error}
       showFilter={true}
       filterType="perWeek"
+      sliceTooltip={HoursBilledPerWeekTooltip}
     />
   )
 }

--- a/apps/web/src/pages/customer/components/HoursBilledPerWeekTooltip.tsx
+++ b/apps/web/src/pages/customer/components/HoursBilledPerWeekTooltip.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react'
+import PropTypes from 'prop-types'
+import { useTheme } from '@nivo/core'
+import { Chip, TableTooltip } from '@nivo/tooltip'
+
+const HoursBilledPerWeekTooltip = ({ slice, axis }) => {
+  const theme = useTheme()
+  const otherAxis = axis === 'x' ? 'y' : 'x'
+
+  const filtered = slice.points.filter((point) => point.data[otherAxis] !== 0)
+
+  return (
+    <TableTooltip
+      rows={filtered.map((point) => [
+        <Chip key="chip" color={point.serieColor} style={theme.tooltip.chip} />,
+        point.serieId,
+        <span key="value" style={theme.tooltip.tableCellValue}>
+          {point.data[`${otherAxis}Formatted`]}
+        </span>,
+      ])}
+    />
+  )
+}
+
+HoursBilledPerWeekTooltip.propTypes = {
+  slice: PropTypes.object.isRequired,
+  axis: PropTypes.oneOf(['x', 'y']).isRequired,
+}
+
+export default memo(HoursBilledPerWeekTooltip)


### PR DESCRIPTION
Dersom en kunde har timer for en gitt uke, vil nå dataserien for alle kunder ha den uka. Dersom en kunde ikke hadde noen timer i den perioden vil dataen bli satt til 0. For å kompensere for flere punkter i tooltip blir disse filtrert bort fra tooltip. Vi kunne også vurdert å sortert og begrenset antall kunder i tooltip, men det får bli i neste omgang.