### PR TITLE
Remove flash of login screen for logged in users

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { createStyles, makeStyles, Theme } from '@material-ui/core/styles'
 import Header from './components/header/Header'
 import Content from './components/Content'
 import Footer from './components/Footer'
+import { useUserInfo } from './context/UserInfoContext'
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -32,6 +33,10 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function App() {
   const classes = useStyles()
+
+  const { user } = useUserInfo()
+  if (user === undefined) return null
+
   return (
     <div className={classes.container}>
       <Header />


### PR DESCRIPTION
A returning user will have a previously set access token in localStorage. If such a token is present we let the UserInfo remain in undefined state for up to 3 seconds to allow the user info to be fetched.

For users that were not logged in in previous session we transition from undefined to null immediately and serve the login page.