### PR TITLE
Remove login flash after completed login by using parameter on redirect

### DIFF
--- a/apps/server/routers/authRouter.ts
+++ b/apps/server/routers/authRouter.ts
@@ -77,7 +77,9 @@ router.get('/callback', async function (req: Request, res: Response) {
     ...cookieSettings,
   })
   res.clearCookie('authReferer')
-  res.redirect(302, getPath(referer))
+  const redirectURL = new URL(referer)
+  redirectURL.searchParams.append('login', 'true')
+  res.redirect(302, redirectURL.toString())
 })
 
 router.get('/userInfo', async function (req: Request, res: Response) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -34,6 +34,13 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function App() {
   const classes = useStyles()
 
+  const url = new URL(window.location.href)
+  if (url.searchParams.has('login')) {
+    localStorage.setItem('login', 'true')
+    url.searchParams.delete('login')
+    history.replaceState(null, '', url)
+  }
+
   const { user } = useUserInfo()
   if (user === undefined) return null
 

--- a/apps/web/src/context/UserInfoContext.tsx
+++ b/apps/web/src/context/UserInfoContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { UserInfo } from '../api/auth/authApiTypes'
 import { getUserInfo } from '../api/data/user/userApi'
-import { getAccessToken } from '../api/auth/authHelpers'
 
 import { isError } from '../api/errorHandling'
 

--- a/apps/web/src/context/UserInfoContext.tsx
+++ b/apps/web/src/context/UserInfoContext.tsx
@@ -42,7 +42,7 @@ export const UserInfoProvider: React.FC<UserInfoProviderProps> = ({
           () => {
             setFetchedUser(null)
           },
-          getAccessToken() ? 3000 : 0
+          localStorage.getItem('login') ? 3000 : 0
         )
         const user = await getUserInfo()
         clearTimeout(timeout)


### PR DESCRIPTION
Fjerner et ekstra tilfellet av å se login siden når man ikke skulle. Legger til login=true i URL når man blir redirectet fra authRouter, App komponenten detekterer dette og setter en egen localStorage item for dette (istedet for å bruker access token), og sletter så login=true fra URLen.

Før:
![login-flash2](https://user-images.githubusercontent.com/6408068/223991641-a82c5476-5501-47fa-8d07-6c56cd1971ab.gif)

Ettter
![login-flash3](https://user-images.githubusercontent.com/6408068/223991658-9707c75a-d74f-40aa-9d41-93ec7ef0520f.gif)
