### PR TITLE
Forenkle graf komponent og bytt til knapper for periodefilter

### DIFF
--- a/apps/web/src/components/charts/ChartCard.tsx
+++ b/apps/web/src/components/charts/ChartCard.tsx
@@ -13,7 +13,6 @@ import RadarChart from './nivo/RadarChart'
 import SunburstChart from './nivo/SunburstChart'
 import MultipleChartCard from './MultipleChartCard'
 import SingularChartCard from './SingularChartCard'
-import { ChartFilterType } from './chartFilters/useFilteredData'
 import { SliceTooltip } from '@nivo/line'
 
 interface SingularChartProps {
@@ -48,9 +47,8 @@ interface ChartCardProps {
   fullSize?: boolean
   data: ChartData | undefined
   error: any
-  showFilter?: boolean
-  filterType?: ChartFilterType
   sliceTooltip?: SliceTooltip
+  extraHeaderContent?: React.ReactNode
 }
 
 const ChartCard = ({
@@ -58,8 +56,7 @@ const ChartCard = ({
   data,
   error,
   title,
-  filterType,
-  showFilter = false,
+  extraHeaderContent,
   ...props
 }: ChartCardProps) => {
   if (error)
@@ -91,8 +88,7 @@ const ChartCard = ({
       fullSize={fullSize}
       title={title}
       data={data}
-      showFilter={showFilter}
-      filterType={filterType}
+      extraHeaderContent={extraHeaderContent}
       {...props}
     />
   )

--- a/apps/web/src/components/charts/SingularChartCard.tsx
+++ b/apps/web/src/components/charts/SingularChartCard.tsx
@@ -2,15 +2,11 @@ import { SingularChartData } from '../../../../../packages/folk-common/types/cha
 import React, { useState } from 'react'
 import { GridItem } from '../gridItem/GridItem'
 import { GridItemHeader } from '../gridItem/GridItemHeader'
-import DropdownPicker from './DropdownPicker'
 import { GridItemContent } from '../gridItem/GridItemContent'
 import { ChartDisplayOptions } from './ChartDisplayOptions'
 import { ToggleBigChartButton } from './ToggleBigChartButton'
 import BigChart from './BigChart'
 import { SingularChart } from './ChartCard'
-import useFilteredData, {
-  ChartFilterType,
-} from './chartFilters/useFilteredData'
 import { SliceTooltip } from '@nivo/line'
 
 interface SingularChartCardProps {
@@ -18,9 +14,8 @@ interface SingularChartCardProps {
   description?: string
   fullSize: boolean
   data: SingularChartData
-  showFilter?: boolean
-  filterType?: ChartFilterType
   sliceTooltip?: SliceTooltip
+  extraHeaderContent?: React.ReactNode
 }
 
 /**
@@ -30,26 +25,24 @@ const SingularChartCard = ({
   title,
   description,
   fullSize = false,
-  showFilter,
-  filterType,
   data,
+  extraHeaderContent,
   ...props
 }: SingularChartCardProps) => {
   const [isBig, setIsBig] = useState(false)
-  const { filterOptions, getFilteredData, setSelectedFilter, selectedFilter } =
-    useFilteredData(filterType, data)
-  const chartData = showFilter ? getFilteredData() : data
 
   return (
     <GridItem fullSize={fullSize}>
       <GridItemHeader title={title} description={description}>
-        {showFilter && (
-          <DropdownPicker
-            values={filterOptions}
-            selected={selectedFilter}
-            onChange={setSelectedFilter}
-          />
-        )}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: 'space-between',
+          }}
+        >
+          {extraHeaderContent && extraHeaderContent}
+        </div>
       </GridItemHeader>
       <GridItemContent>
         {/* Sub header containing only the increase size-button */}
@@ -58,11 +51,11 @@ const SingularChartCard = ({
         </ChartDisplayOptions>
 
         {/* The small chart */}
-        <SingularChart isBig={false} chartData={chartData} {...props} />
+        <SingularChart isBig={false} chartData={data} {...props} />
 
         {/* The big chart */}
         <BigChart open={isBig} onClose={() => setIsBig(false)}>
-          <SingularChart isBig={isBig} chartData={chartData} {...props} />
+          <SingularChart isBig={isBig} chartData={data} {...props} />
         </BigChart>
       </GridItemContent>
     </GridItem>

--- a/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
@@ -38,9 +38,9 @@ const usePerWeekFilter = (data: SingularChartData): FilteredData => {
   const filterOptions: PerWeekFilterOptions[] = [
     'Uke',
     'Måned',
-    'Kvartal',
-    'Halvår',
-    'År',
+    //'Kvartal',
+    //'Halvår',
+    //'År',
   ]
 
   const [selectedFilter, setSelectedFilter] = useState(filterOptions[0])

--- a/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerCustomerCard.tsx
@@ -2,18 +2,30 @@ import React from 'react'
 import ChartCard from '../../../components/charts/ChartCard'
 import { useHoursBilledPerCustomerCharts } from '../../../api/data/customer/customerQueries'
 import { POSSIBLE_OLD_DATA_WARNING } from './messages'
+import useFilteredData from '../../../components/charts/chartFilters/useFilteredData'
+import DropdownPicker from '../../../components/charts/DropdownPicker'
 
 const HoursBilledPerCustomerCard = () => {
   const { data, error } = useHoursBilledPerCustomerCharts()
+
+  const { filterOptions, getFilteredData, setSelectedFilter, selectedFilter } =
+    useFilteredData('perCustomer', data)
+
+  const chartData = getFilteredData()
 
   return (
     <ChartCard
       title="Timer brukt per kunde"
       description={POSSIBLE_OLD_DATA_WARNING}
-      data={data}
+      data={chartData}
       error={error}
-      showFilter={true}
-      filterType="perCustomer"
+      extraHeaderContent={
+        <DropdownPicker
+          values={filterOptions}
+          selected={selectedFilter}
+          onChange={setSelectedFilter}
+        />
+      }
     />
   )
 }

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -50,7 +50,7 @@ const HoursBilledPerWeekCard = () => {
                   <FormControlLabel
                     key={option}
                     value={option}
-                    control={<Radio />}
+                    control={<Radio color="primary" />}
                     label={option}
                     style={{ flexGrow: 1 }}
                   />

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -4,7 +4,15 @@ import { useHoursBilledPerWeekCharts } from '../../../api/data/customer/customer
 import { POSSIBLE_OLD_DATA_WARNING } from './messages'
 import HoursBilledPerWeekTooltip from '../components/HoursBilledPerWeekTooltip'
 import useFilteredData from '../../../components/charts/chartFilters/useFilteredData'
-import DropdownPicker from '../../../components/charts/DropdownPicker'
+import { GridItem } from '../../../components/gridItem/GridItem'
+import {
+  Box,
+  RadioGroup,
+  FormLabel,
+  FormControlLabel,
+  Radio,
+  FormControl,
+} from '@material-ui/core'
 
 const HoursBilledPerWeekCard = () => {
   const { data, error } = useHoursBilledPerWeekCharts()
@@ -15,20 +23,44 @@ const HoursBilledPerWeekCard = () => {
   const chartData = getFilteredData()
 
   return (
-    <ChartCard
-      title="Timer brukt per periode"
-      description={POSSIBLE_OLD_DATA_WARNING}
-      data={chartData}
-      error={error}
-      sliceTooltip={HoursBilledPerWeekTooltip}
-      extraHeaderContent={
-        <DropdownPicker
-          values={filterOptions}
-          selected={selectedFilter}
-          onChange={setSelectedFilter}
-        />
-      }
-    />
+    <GridItem fullSize={true}>
+      <ChartCard
+        title="Timer brukt per periode"
+        description={POSSIBLE_OLD_DATA_WARNING}
+        data={chartData}
+        error={error}
+        fullSize={true}
+        sliceTooltip={HoursBilledPerWeekTooltip}
+        extraHeaderContent={
+          <FormControl component="fieldset">
+            <FormLabel>Grupper etter</FormLabel>
+            <Box display="flex" flexWrap="nowrap" width="100%">
+              <RadioGroup
+                style={{ flexWrap: 'nowrap' }}
+                row
+                value={selectedFilter}
+                onChange={(event) => {
+                  const option = filterOptions.find(
+                    (option) => option === event.target.value
+                  )
+                  setSelectedFilter(option)
+                }}
+              >
+                {filterOptions.map((option) => (
+                  <FormControlLabel
+                    key={option}
+                    value={option}
+                    control={<Radio />}
+                    label={option}
+                    style={{ flexGrow: 1 }}
+                  />
+                ))}
+              </RadioGroup>
+            </Box>
+          </FormControl>
+        }
+      />
+    </GridItem>
   )
 }
 

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -3,19 +3,31 @@ import ChartCard from '../../../components/charts/ChartCard'
 import { useHoursBilledPerWeekCharts } from '../../../api/data/customer/customerQueries'
 import { POSSIBLE_OLD_DATA_WARNING } from './messages'
 import HoursBilledPerWeekTooltip from '../components/HoursBilledPerWeekTooltip'
+import useFilteredData from '../../../components/charts/chartFilters/useFilteredData'
+import DropdownPicker from '../../../components/charts/DropdownPicker'
 
 const HoursBilledPerWeekCard = () => {
   const { data, error } = useHoursBilledPerWeekCharts()
+
+  const { filterOptions, getFilteredData, setSelectedFilter, selectedFilter } =
+    useFilteredData('perWeek', data)
+
+  const chartData = getFilteredData()
 
   return (
     <ChartCard
       title="Timer brukt per periode"
       description={POSSIBLE_OLD_DATA_WARNING}
-      data={data}
+      data={chartData}
       error={error}
-      showFilter={true}
-      filterType="perWeek"
       sliceTooltip={HoursBilledPerWeekTooltip}
+      extraHeaderContent={
+        <DropdownPicker
+          values={filterOptions}
+          selected={selectedFilter}
+          onChange={setSelectedFilter}
+        />
+      }
     />
   )
 }

--- a/apps/web/src/pages/customer/components/CustomerOverview.tsx
+++ b/apps/web/src/pages/customer/components/CustomerOverview.tsx
@@ -6,7 +6,6 @@ import { HoursBilledPerCustomerCard, HoursBilledPerWeekCard } from '../cards'
 export const CustomerOverview = () => {
   return (
     <Grid container spacing={2}>
-      <HoursBilledPerCustomerCard />
       <HoursBilledPerWeekCard />
       <CustomerCardList />
     </Grid>


### PR DESCRIPTION
Grafene for "Timer brukt per kunde" og "Timer brukt per periode" la til funksjonaliteten i useFilteredData (misvisende navn, er mer useMappedData) den generiske grafkomponenten. Dette førte til at grafkomponentene ble unødvendig ekstra kompliserte. Dette fjernes nå til fordel for en mulighet for å legge til custom innhold i headeren, som lar oss legge til grensesnittet for å velge hvilken data vi skal vise for disse grafene fra HoursBilledPerWeekCard / HourHoursBilledPerCustomerCard komponentene.

"Timer brukt per kunde" grafen ikke skal være med i det nye designet og er fjernet. Derfor er det egentlig ikke sikkert vi trenger å ha extra header fuknsjonaliteten helle, siden nå er "Timer brukt per periode" den eneste som bruker denne funksjonaliteten, for å bytte mellom å gruppere data på uker eller måneder. Hele denne grafen skal ha flere ting som periodevalg, kundefilter, annen størrelse for å nevne noe, så det er ikke sikkert den skal bruke ChartCard komponenten i det hele tatt etterhvert.

Bytter også om periodevalg fra en Dropdown til radio buttons (closes #427)