### PR TITLE
Set employee.title fallback in backend instead of frontend

### DIFF
--- a/apps/server/routers/customer/customerAggregation.ts
+++ b/apps/server/routers/customer/customerAggregation.ts
@@ -42,7 +42,7 @@ function createEmployeeForCustomerList(
         image_url: getStorageUrl(employee.image_key),
         user_id: employee.user_id,
       },
-      employee.title || null,
+      employee.title || 'Ansatt',
       `${employee.customer_name}: ${employee.work_order_description}`,
       createCvLinks(employee.link),
     ],

--- a/apps/server/routers/employees/employeesAggregation.ts
+++ b/apps/server/routers/employees/employeesAggregation.ts
@@ -46,7 +46,7 @@ export const aggregateEmployeeTable = (
           email: employee.email,
           image_url: getStorageUrl(employee.image_key),
         },
-        employee.title || null,
+        employee.title || 'Ansatt',
         getProjectStatusForEmployee(
           jobRotationInformation,
           employeeWorkStatus,

--- a/apps/web/src/pages/employee/table/EmployeeTable.tsx
+++ b/apps/web/src/pages/employee/table/EmployeeTable.tsx
@@ -51,9 +51,6 @@ export function EmployeeTable() {
                 title: 'Tittel',
                 width: 222,
                 headerCell: SortableHeaderCell,
-                getValue: (jobTitle: string | undefined | null) => {
-                  return jobTitle || 'Ansatt'
-                },
               },
               {
                 title: 'Prosjektstatus',


### PR DESCRIPTION
The frontend solution did not correctly affect the rendered value, only the value used for sorting. This solution also fixes potential future usages of the field.