### PR TITLE
Add customer filter to HoursBilledPerWeek graph

### DIFF
--- a/apps/web/src/components/charts/chartFilters/useFilteredData.ts
+++ b/apps/web/src/components/charts/chartFilters/useFilteredData.ts
@@ -1,13 +1,12 @@
 import { SingularChartData } from '../../../../../../packages/folk-common/types/chartTypes'
-import usePerWeekFilter, { PerWeekFilterOptions } from './usePerWeekFilter'
 import perCustomerFilter, {
   PerCustomerFilterOptions,
 } from './usePerCustomerFilter'
 import { Dispatch, SetStateAction } from 'react'
 
-export type ChartFilterType = 'perWeek' | 'perCustomer'
+export type ChartFilterType = 'perCustomer'
 
-type FilterOption = PerCustomerFilterOptions | PerWeekFilterOptions
+type FilterOption = PerCustomerFilterOptions
 
 export type FilteredData = {
   filterOptions: FilterOption[]
@@ -18,12 +17,10 @@ export type FilteredData = {
 
 const getHook = (type: ChartFilterType) => {
   switch (type) {
-    case 'perWeek':
-      return usePerWeekFilter
     case 'perCustomer':
       return perCustomerFilter
     default:
-      return usePerWeekFilter
+      return perCustomerFilter
   }
 }
 

--- a/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
@@ -1,15 +1,11 @@
 import { SingularChartData } from '../../../../../../packages/folk-common/types/chartTypes'
-import { useState } from 'react'
-import { FilteredData } from './useFilteredData'
+import { Dispatch, SetStateAction, useMemo, useState } from 'react'
 
-export type PerWeekFilterOptions = 'Uke' | 'Måned' | 'Kvartal' | 'Halvår' | 'År'
+export type PerWeekFilterOptions = 'Uke' | 'Måned'
 
 type DateDisplay = {
   month: string
-  year: string
-  halfyear: string
   week: string
-  quarter: string
   date: Date
 }
 
@@ -21,31 +17,31 @@ function getDateDisplay(regPeriod: string): DateDisplay {
   date.setDate(date.getDate() + (1 - date.getDay()))
 
   const month = date.toLocaleString('no-NO', { month: 'short' })
-  const quarter = Math.floor((date.getMonth() + 3) / 3)
-  const halfyear = date.getMonth() <= 5 ? 'første' : 'andre'
 
   return {
     month: `${y} - ${month}`,
-    year: `${y}`,
-    halfyear: `${y} - ${halfyear} halvår`,
     week: `${y} - Uke ${w}`,
-    quarter: `${y} - Q${quarter}`,
     date: date,
   }
 }
 
-const usePerWeekFilter = (data: SingularChartData): FilteredData => {
-  const filterOptions: PerWeekFilterOptions[] = [
-    'Uke',
-    'Måned',
-    //'Kvartal',
-    //'Halvår',
-    //'År',
-  ]
+export type PerWeekFilteredData = {
+  filterOptions: PerWeekFilterOptions[]
+  selectedFilter: PerWeekFilterOptions
+  setSelectedFilter: Dispatch<SetStateAction<PerWeekFilterOptions>>
+  weeklyData: SingularChartData
+  monthlyData: SingularChartData
+}
+
+const usePerWeekFilter = (data: SingularChartData): PerWeekFilteredData => {
+  const filterOptions: PerWeekFilterOptions[] = ['Uke', 'Måned']
 
   const [selectedFilter, setSelectedFilter] = useState(filterOptions[0])
 
-  const getFilteredData = (): SingularChartData => {
+  const groupDataByTimePeriod = (
+    data: SingularChartData,
+    period: PerWeekFilterOptions
+  ): SingularChartData => {
     if (data && data.type === 'LineChart') {
       const filteredData = data.data.map((customer) => {
         const filteredData = customer.data
@@ -53,24 +49,18 @@ const usePerWeekFilter = (data: SingularChartData): FilteredData => {
             const date = getDateDisplay(v.x)
             const value = { ...v, date: date.date }
 
-            switch (selectedFilter) {
+            switch (period) {
               case 'Uke':
                 return { ...value, x: date.week }
               case 'Måned':
                 return { ...value, x: date.month }
-              case 'Kvartal':
-                return { ...value, x: date.quarter }
-              case 'Halvår':
-                return { ...value, x: date.halfyear }
-              case 'År':
-                return { ...value, x: date.year }
               default:
                 return value
             }
           })
           .reduce((list, value) => {
             const sum = list
-              .filter((o) => o.x === value.x)
+              .filter((o) => o.x === value)
               .reduce((v, o) => o.y + v, 0)
 
             return [
@@ -98,7 +88,19 @@ const usePerWeekFilter = (data: SingularChartData): FilteredData => {
     }
   }
 
-  return { filterOptions, selectedFilter, setSelectedFilter, getFilteredData }
+  const weeklyData = useMemo(() => groupDataByTimePeriod(data, 'Uke'), [data])
+  const monthlyData = useMemo(
+    () => groupDataByTimePeriod(data, 'Måned'),
+    [data]
+  )
+
+  return {
+    filterOptions,
+    selectedFilter,
+    setSelectedFilter,
+    weeklyData,
+    monthlyData,
+  }
 }
 
 export default usePerWeekFilter

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekCard.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
 import ChartCard from '../../../components/charts/ChartCard'
 import { useHoursBilledPerWeekCharts } from '../../../api/data/customer/customerQueries'
 import { POSSIBLE_OLD_DATA_WARNING } from './messages'
 import HoursBilledPerWeekTooltip from '../components/HoursBilledPerWeekTooltip'
-import useFilteredData from '../../../components/charts/chartFilters/useFilteredData'
 import { GridItem } from '../../../components/gridItem/GridItem'
+import { GridItemHeader } from '../../../components/gridItem/GridItemHeader'
 import {
   Box,
   RadioGroup,
@@ -12,54 +11,187 @@ import {
   FormControlLabel,
   Radio,
   FormControl,
+  Checkbox,
 } from '@mui/material'
+import { styled } from '@mui/styles'
+import usePerWeekFilter from '../../../components/charts/chartFilters/usePerWeekFilter'
+import { GridItemContent } from '../../../components/gridItem/GridItemContent'
+import { BaseSkeleton } from '../../../components/skeletons/BaseSkeleton'
 
-const HoursBilledPerWeekCard = () => {
+const GridContainer = styled('div')({
+  display: 'grid',
+  gridTemplateColumns: '3fr 1fr',
+  gridGap: '1rem',
+})
+
+const CustomerFilterWrapper = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '420px',
+  textAlign: 'right',
+  background: 'white',
+})
+
+const ScrollableDiv = styled('div')({
+  overflowY: 'scroll',
+})
+
+const CheckboxFlexWrapper = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+interface HoursBilledPerWeekCardProps {
+  selectedCustomerIds: string[]
+  setSelectedCustomerIds: (ids: string[]) => void
+}
+
+const HoursBilledPerWeekCard = ({
+  selectedCustomerIds,
+  setSelectedCustomerIds,
+}: HoursBilledPerWeekCardProps) => {
   const { data, error } = useHoursBilledPerWeekCharts()
+  const {
+    filterOptions,
+    selectedFilter,
+    setSelectedFilter,
+    weeklyData,
+    monthlyData,
+  } = usePerWeekFilter(data)
 
-  const { filterOptions, getFilteredData, setSelectedFilter, selectedFilter } =
-    useFilteredData('perWeek', data)
+  const customers =
+    data === undefined ? [] : data?.data?.map((item) => item.id as string)
 
-  const chartData = getFilteredData()
+  const selectedCustomers = customers.filter((customer) =>
+    selectedCustomerIds.includes(customer)
+  )
+  const unselectedCustomers = customers.filter(
+    (customer) => !selectedCustomerIds.includes(customer)
+  )
+  const handleSelectAll = () => {
+    setSelectedCustomerIds(customers)
+  }
+  const handleSelectNone = () => {
+    setSelectedCustomerIds([])
+  }
+
+  const handleCheckboxChange = (event, customerId) => {
+    if (event.target.checked) {
+      setSelectedCustomerIds([...selectedCustomerIds, customerId])
+    } else {
+      setSelectedCustomerIds(
+        selectedCustomerIds.filter((id) => id !== customerId)
+      )
+    }
+  }
+
+  const chartData = selectedFilter === 'Uke' ? weeklyData : monthlyData
+  const filteredData =
+    data === undefined
+      ? undefined
+      : {
+          ...data,
+          data: chartData?.data?.filter((customer) => {
+            return selectedCustomerIds.includes(customer.id as string)
+          }),
+        }
 
   return (
-    <GridItem fullSize={true}>
-      <ChartCard
-        title="Timer brukt per periode"
-        description={POSSIBLE_OLD_DATA_WARNING}
-        data={chartData}
-        error={error}
-        fullSize={true}
-        sliceTooltip={HoursBilledPerWeekTooltip}
-        extraHeaderContent={
-          <FormControl component="fieldset">
-            <FormLabel>Grupper etter</FormLabel>
-            <Box display="flex" flexWrap="nowrap" width="100%">
-              <RadioGroup
-                style={{ flexWrap: 'nowrap' }}
-                row
-                value={selectedFilter}
-                onChange={(event) => {
-                  const option = filterOptions.find(
-                    (option) => option === event.target.value
-                  )
-                  setSelectedFilter(option)
-                }}
-              >
-                {filterOptions.map((option) => (
-                  <FormControlLabel
-                    key={option}
-                    value={option}
-                    control={<Radio color="primary" />}
-                    label={option}
-                    style={{ flexGrow: 1 }}
-                  />
-                ))}
-              </RadioGroup>
-            </Box>
-          </FormControl>
-        }
-      />
+    <GridItem fullSize>
+      {filteredData === undefined ? (
+        <BaseSkeleton variant="rectangular" height={420}></BaseSkeleton>
+      ) : (
+        <GridContainer>
+          <ChartCard
+            title="Timer brukt per periode"
+            description={POSSIBLE_OLD_DATA_WARNING}
+            data={filteredData}
+            error={error}
+            fullSize={true}
+            sliceTooltip={HoursBilledPerWeekTooltip}
+            extraHeaderContent={
+              <FormControl component="fieldset">
+                <FormLabel>Grupper etter</FormLabel>
+                <Box display="flex" flexWrap="nowrap" width="100%">
+                  <RadioGroup
+                    style={{ flexWrap: 'nowrap' }}
+                    row
+                    value={selectedFilter}
+                    onChange={(event) => {
+                      const option = filterOptions.find(
+                        (option) => option === event.target.value
+                      )
+                      setSelectedFilter(option)
+                    }}
+                  >
+                    {filterOptions.map((option) => (
+                      <FormControlLabel
+                        key={option}
+                        value={option}
+                        control={<Radio color="primary" />}
+                        label={option}
+                        style={{ flexGrow: 1 }}
+                      />
+                    ))}
+                  </RadioGroup>
+                </Box>
+              </FormControl>
+            }
+          />
+          <CustomerFilterWrapper>
+            <GridItemHeader title="Filtrer kunder">
+              <Checkbox
+                checked={selectedCustomerIds.length === customers.length}
+                onChange={
+                  selectedCustomerIds.length === customers.length
+                    ? handleSelectNone
+                    : handleSelectAll
+                }
+                name="select-all"
+              />
+            </GridItemHeader>
+
+            <ScrollableDiv>
+              <GridItemContent>
+                <CheckboxFlexWrapper>
+                  {selectedCustomers.map((customer) => (
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={selectedCustomerIds.includes(customer)}
+                          onChange={(event) =>
+                            handleCheckboxChange(event, customer)
+                          }
+                          name={customer}
+                        />
+                      }
+                      label={customer}
+                      labelPlacement="start"
+                      key={customer}
+                    />
+                  ))}
+                  {unselectedCustomers.map((customer) => (
+                    <FormControlLabel
+                      control={
+                        <Checkbox
+                          checked={selectedCustomerIds.includes(customer)}
+                          onChange={(event) =>
+                            handleCheckboxChange(event, customer)
+                          }
+                          name={customer}
+                        />
+                      }
+                      label={customer}
+                      labelPlacement="start"
+                      key={customer}
+                    />
+                  ))}
+                </CheckboxFlexWrapper>
+              </GridItemContent>
+            </ScrollableDiv>
+          </CustomerFilterWrapper>
+        </GridContainer>
+      )}
     </GridItem>
   )
 }

--- a/apps/web/src/pages/customer/components/CustomerOverview.tsx
+++ b/apps/web/src/pages/customer/components/CustomerOverview.tsx
@@ -1,12 +1,29 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import CustomerCardList from './CustomerCardList'
 import { Grid } from '@mui/material'
 import { HoursBilledPerWeekCard } from '../cards'
 
 export const CustomerOverview = () => {
+  const [selectedCustomerIds, setSelectedCustomerIds] = useState([])
+  useEffect(() => {
+    const selectedCustomerIds = localStorage.getItem('selectedCustomerIds')
+    if (selectedCustomerIds) {
+      setSelectedCustomerIds(JSON.parse(selectedCustomerIds))
+    }
+  }, [])
+  useEffect(() => {
+    localStorage.setItem(
+      'selectedCustomerIds',
+      JSON.stringify(selectedCustomerIds)
+    )
+  }, [selectedCustomerIds])
+
   return (
     <Grid container spacing={2}>
-      <HoursBilledPerWeekCard />
+      <HoursBilledPerWeekCard
+        selectedCustomerIds={selectedCustomerIds}
+        setSelectedCustomerIds={setSelectedCustomerIds}
+      />
       <CustomerCardList />
     </Grid>
   )


### PR DESCRIPTION
Adds a customer filter on the graph (the state is in the customer overview page, so it can be used for the customer cards also in the future).

Also removes the usePerWeekFilter from the common useFilteredData to memoize the data.