### PR TITLE
Changed renderOption to li, added props

### DIFF
--- a/apps/web/src/components/filter/FilterInput.tsx
+++ b/apps/web/src/components/filter/FilterInput.tsx
@@ -90,13 +90,13 @@ export default function FilterInput({
       className={classes.autocomplete}
       onChange={handleCategoryChange}
       renderOption={(props, option, state) => (
-        <div className={classes.option}>
+        <li className={classes.option} {...props}>
           <StyledCheckBox
             className={classes.checkbox}
             checked={state.selected}
           />
           {option.category}
-        </div>
+        </li>
       )}
       renderInput={(params: any) => (
         <div ref={params.InputProps.ref}>


### PR DESCRIPTION
Fant følgende i migreringsdokumentasjonen for oppgradering til MUI 5:

> renderOption should now return the full DOM structure of the option.

I eksempelet for hvordan "recover from the change" hadde de brukt lister, og importert props på liste-elementet. Gjorde det samme i koden hos oss, og ser ut til at det virker nå.