### PR TITLE
Bumped aws-sdk version and adjusted import

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@folk/common": "workspace:^",
     "@vendia/serverless-express": "^4.10.1",
-    "aws-sdk": "^2.1278.0",
+    "aws-sdk": "^2.1384.0",
     "axios": "^1.2.1",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",

--- a/apps/server/repository/util.ts
+++ b/apps/server/repository/util.ts
@@ -1,5 +1,5 @@
-import AWS from 'aws-sdk'
-AWS.config.update({ region: 'eu-central-1' })
+import { config } from 'aws-sdk'
+config.update({ region: 'eu-central-1' })
 
 export const range = (x: number, y: number) =>
   Array.from(

--- a/yarn.lock
+++ b/yarn.lock
@@ -5519,9 +5519,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1278.0":
-  version: 2.1278.0
-  resolution: "aws-sdk@npm:2.1278.0"
+"aws-sdk@npm:^2.1384.0":
+  version: 2.1384.0
+  resolution: "aws-sdk@npm:2.1384.0"
   dependencies:
     buffer: 4.9.2
     events: 1.1.1
@@ -5532,8 +5532,8 @@ __metadata:
     url: 0.10.3
     util: ^0.12.4
     uuid: 8.0.0
-    xml2js: 0.4.19
-  checksum: 9375ec5dea3287e2bc05c302d7ba7d4e4fdc5c473ad32452fc7cee7bbc827baa8a3289a035312b55c98e11e9b9a11fbc5f6409b8199b0b8af46565686173657c
+    xml2js: 0.5.0
+  checksum: 0fa76564afa4b90ed49efd3dd4dc6c1733899611aa3c7db74040c26c988730e6406152199920e480785558c5965fe40dd9ad2c72733f89e1c55b1073b6e7ca43
   languageName: node
   linkType: hard
 
@@ -15769,7 +15769,7 @@ __metadata:
     "@types/express": ^4.17.15
     "@types/node": ^18.11.17
     "@vendia/serverless-express": ^4.10.1
-    aws-sdk: ^2.1278.0
+    aws-sdk: ^2.1384.0
     axios: ^1.2.1
     cookie-parser: ^1.4.6
     cross-env: ^7.0.3
@@ -18203,6 +18203,23 @@ __metadata:
     sax: ">=0.6.0"
     xmlbuilder: ~9.0.1
   checksum: ca8b2fee430d450a18947786bfd7cd1a353ee00fc6fd550acbc8a8e65f1b4df5e9786fcb2990c1a5514ecd554d445fb74e1d716b3a4fcfffc10554aeb5db482b
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.5.0":
+  version: 0.5.0
+  resolution: "xml2js@npm:0.5.0"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 1aa71d62e5bc2d89138e3929b9ea46459157727759cbc62ef99484b778641c0cd21fb637696c052d901a22f82d092a3e740a16b4ce218e81ac59b933535124ea
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
xml2js er i bruk i 2 forskjellige versjoner av aws-sdk. Den ene har vi installert selv, og den er bumpet med denne PRen. Med oppdateringen, kommer det noen justeringer i syntax, bl.a. importer fra pakka. Den importsyntaxen er også oppdatert i denne PRen, slik at den ikke skal plage oss seinere.

Nevnt i #472 