### PR TITLE
Fix monthly hours billed graph for month

### DIFF
--- a/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
+++ b/apps/web/src/components/charts/chartFilters/usePerWeekFilter.ts
@@ -44,17 +44,24 @@ const usePerWeekFilter = (data: SingularChartData): PerWeekFilteredData => {
   ): SingularChartData => {
     if (data && data.type === 'LineChart') {
       const filteredData = data.data.map((customer) => {
+        let monthValue = 0
+        let month = null
         const filteredData = customer.data
           .map((v) => {
             const date = getDateDisplay(v.x)
             const value = { ...v, date: date.date }
+            if (!month || date.month != month) {
+              month = date.month
+              monthValue = 0
+            }
+            monthValue += value.y
             switch (period) {
               case 'Uke':
                 return { ...value, x: date.week }
               case 'Måned': {
                 const monthDate = new Date(date.date)
                 monthDate.setDate(1)
-                return { ...value, x: date.month, date: monthDate }
+                return { date: monthDate, x: date.month, y: monthValue }
               }
               default:
                 return value


### PR DESCRIPTION
The problem in this bug was that the monthValues wasn't added together, such that the last value of the month would be the one that counted. I provided this adding