### PR TITLE
Fix blank screen when employee-search

### DIFF
--- a/apps/server/routers/employees/employeesAggregation.ts
+++ b/apps/server/routers/employees/employeesAggregation.ts
@@ -112,14 +112,14 @@ export const aggregateEmployeeCompetenceAndMotivation = (
 
     categoriesMap[category][subCategory] = {
       category: subCategory,
-      motivation: Math.max(0, subCategoryMotivation),
-      competence: Math.max(0, subCategoryCompetence),
+      motivation: subCategoryMotivation,
+      competence: subCategoryCompetence,
     }
 
     categoriesMap['Hovedkategorier'][category] = {
       category,
-      motivation: Math.max(0, categoryMotivationAvg),
-      competence: Math.max(0, categoryCompetenceAvg),
+      motivation: categoryMotivationAvg,
+      competence: categoryCompetenceAvg,
     }
   })
 

--- a/apps/server/routers/employees/employeesAggregation.ts
+++ b/apps/server/routers/employees/employeesAggregation.ts
@@ -112,14 +112,14 @@ export const aggregateEmployeeCompetenceAndMotivation = (
 
     categoriesMap[category][subCategory] = {
       category: subCategory,
-      motivation: subCategoryMotivation,
-      competence: subCategoryCompetence,
+      motivation: Math.max(0, subCategoryMotivation),
+      competence: Math.max(0, subCategoryCompetence),
     }
 
     categoriesMap['Hovedkategorier'][category] = {
       category,
-      motivation: categoryMotivationAvg,
-      competence: categoryCompetenceAvg,
+      motivation: Math.max(0, categoryMotivationAvg),
+      competence: Math.max(0, categoryCompetenceAvg),
     }
   })
 

--- a/apps/web/src/components/sortableTable/SortableMUITable.tsx
+++ b/apps/web/src/components/sortableTable/SortableMUITable.tsx
@@ -19,7 +19,7 @@ export function getSearchableColumns<T>(
 ): SearchableColumn<T>[] {
   const result: SearchableColumn<T>[] = []
   columns.forEach((column, index) => {
-    if (column.sortValue) {
+    if (column.searchValue) {
       result.push({
         columnIndex: index,
         getSearchValue: column.searchValue,

--- a/apps/web/src/components/sortableTable/SortableMUITable.tsx
+++ b/apps/web/src/components/sortableTable/SortableMUITable.tsx
@@ -22,7 +22,7 @@ export function getSearchableColumns<T>(
     if (column.sortValue) {
       result.push({
         columnIndex: index,
-        getSearchValue: column.sortValue,
+        getSearchValue: column.searchValue,
       })
     }
   })

--- a/apps/web/src/components/sortableTable/tableTypes.tsx
+++ b/apps/web/src/components/sortableTable/tableTypes.tsx
@@ -38,6 +38,7 @@ export interface MUITableConfig<T> {
   header?: () => ReactNode
   checkBox?: CheckBoxHeader
   sortValue?: sortValueFn<T>
+  searchValue?: GetColumnValueFn
   sortFn?: (a: T, b: T) => number
 }
 

--- a/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
+++ b/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
@@ -123,18 +123,21 @@ const employeeForCustomerConfig = [
     },
     width: 395,
     sortValue: (column: ConsultantInfo) => column.name,
+    searchValue: (consultant: ConsultantInfo) => consultant.name,
   },
   {
     label: 'Tittel',
     width: 222,
     render: (row: EmployeeCustomerRow) => row.jobTitle,
     sortValue: (title: string) => title,
+    searchValue: (jobTitle: string) => jobTitle,
   },
   {
     label: 'Kunde',
     render: (row: EmployeeCustomerRow) => row.customerAndProject,
     width: 337,
     sortValue: (customer: string) => customer ?? '',
+    searchValue: (customer: string) => customer ?? '',
   },
   {
     label: 'CV',

--- a/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
+++ b/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
@@ -63,12 +63,14 @@ export const getEmployeeTableConfig = (checkBox?: CheckBoxHeader) =>
       },
       checkBox: checkBox,
       sortValue: (row: EmployeeRow) => row.employeeInfo.name,
+      searchValue: (consultant: ConsultantInfo) => consultant.name,
     },
     {
       label: 'Tittel',
       width: 222,
       render: (row: EmployeeRow) => row.jobTitle,
       sortValue: (row: EmployeeRow) => row.jobTitle,
+      searchValue: (jobTitle: string) => jobTitle,
     },
     {
       label: 'Prosjektstatus',
@@ -84,6 +86,7 @@ export const getEmployeeTableConfig = (checkBox?: CheckBoxHeader) =>
       ),
       width: 337,
       sortValue: (row: EmployeeRow) => row.primaryCustomer.customer ?? '',
+      searchValue: (customerProject: Customer) => customerProject.customer,
     },
     {
       label: 'CV',


### PR DESCRIPTION
Søkeverdien som ble sendt inn førte data over fra EmployeeRow til ønsket element når det egt var EmployeeTableRow man burde se på. Lagt til nytt element searchValue som overfører mellom riktige verdier