### PR TITLE
#549 - added responsive ticks to the bottom of customer billing graph

### DIFF
--- a/apps/web/src/components/charts/nivo/LineChart.tsx
+++ b/apps/web/src/components/charts/nivo/LineChart.tsx
@@ -17,6 +17,18 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
       },
     },
   }
+  const mapTicks = () => {
+    if (!props.data || !props.data[0]) {
+      return null
+    }
+
+    const data = props.data[0].data
+    const tickInterval = Math.round(data.length / 6)
+    return data
+      .filter((point) => data.indexOf(point) % tickInterval === 0)
+      .map((point) => point.x)
+  }
+
   return (
     <div style={{ width: '100%', height: isBig ? '400px' : '280px' }}>
       <ResponsiveLine
@@ -32,8 +44,7 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
           reverse: false,
         }}
         axisTop={null}
-        axisBottom={isBig ? {} : null}
-        axisRight={null}
+        axisBottom={{ tickValues: mapTicks() }}
         colors={chartColors}
         curve="monotoneX"
         enableArea={true}

--- a/apps/web/src/components/charts/nivo/LineChart.tsx
+++ b/apps/web/src/components/charts/nivo/LineChart.tsx
@@ -45,6 +45,7 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
         }}
         axisTop={null}
         axisBottom={{ tickValues: mapTicks() }}
+        axisRight={null}
         colors={chartColors}
         curve="monotoneX"
         enableArea={true}


### PR DESCRIPTION
Adds labels on the X-axis of the customer line-graph.
Its set up to responsively add the number of labels by the amount of data to prevent cluttering, but it will max out at 6 or 7.
You can change this amount by changing the number in the `tickInterval` variable.