### PR TITLE
[Bugfix] Fikset feil variabel brukt som sortValue i listevisning.

### DIFF
--- a/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
+++ b/apps/web/src/pages/employee/table/SortableEmployeeTable.tsx
@@ -140,14 +140,14 @@ const employeeForCustomerConfig = [
     label: 'Tittel',
     width: 222,
     render: (row: EmployeeCustomerRow) => row.jobTitle,
-    sortValue: (title: string) => title,
+    sortValue: (row: EmployeeCustomerRow) => row.jobTitle,
     searchValue: (jobTitle: string) => jobTitle,
   },
   {
     label: 'Kunde',
     render: (row: EmployeeCustomerRow) => row.customerAndProject,
     width: 337,
-    sortValue: (customer: string) => customer ?? '',
+    sortValue: (row: EmployeeCustomerRow) => row.customerAndProject,
     searchValue: (customer: string) => customer ?? '',
   },
   {


### PR DESCRIPTION
#### Hva var problemet:
Sortering av ansatte på tittel og kunde fungerte ikke i oversikten over ansatte for kunder i listevisningen.
Dette var fordi variabelen som ble brukt som sorteringsverdi for de kolonnene ikke var riktig.

#### Hvordan ble det løst:
Endret variabelen til å komme fra EmployeeCustomerRow.