### PR TITLE
[Feature] Ny ansattkort-popup i organsisasjonsstrukturen

### DIFF
--- a/apps/web/src/pages/organizationStructure/Components/NameText.tsx
+++ b/apps/web/src/pages/organizationStructure/Components/NameText.tsx
@@ -96,7 +96,7 @@ const NameText = ({ children, employee, searchTerm, ...rest }: Props) => {
     <>
       <text
         onClick={handleOpenEmployeeCard}
-        style={{ cursor: 'hand' }}
+        style={{ cursor: 'pointer' }}
         stroke={halo}
         strokeWidth={haloWidth}
         paintOrder="stroke"

--- a/apps/web/src/pages/organizationStructure/Components/NameText.tsx
+++ b/apps/web/src/pages/organizationStructure/Components/NameText.tsx
@@ -1,6 +1,75 @@
-import { useTheme } from '@mui/material'
-import { ReactNode } from 'react'
+import { Box, Button, Modal, styled, useTheme } from '@mui/material'
+import { ReactNode, useState } from 'react'
 import { EmployeeProfileInformation } from 'server/routers/employees/employeesTypes'
+import { useEmployeeProfile } from '../../../api/data/employee/employeeQueries'
+
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid black',
+  boxShadow: 24,
+  pl: 4,
+  pr: 4,
+  pt: 2,
+  pb: 2,
+}
+
+const EmployeeCard = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+})
+
+const EmployeeCardName = styled('div')({
+  fontSize: 20,
+  fontWeight: 600,
+})
+
+const EmployeeCardContent = styled('div')({
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  gap: 16,
+  width: '100%',
+})
+
+const EmployeeCardContentLeft = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'start',
+  gap: 8,
+  width: '65%',
+})
+
+const EmployeeCardContentRight = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: 16,
+  width: '35%',
+})
+
+const EmployeeCardField = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  flexWrap: 'wrap',
+})
+
+const EmployeeCardFieldLabel = styled('div')({
+  fontWeight: 600,
+})
+
+const EmployeeCardFieldValue = styled('div')({})
+
+const EmployeeCardImage = styled('img')({
+  borderRadius: 90,
+  width: '100%',
+})
 
 interface Props {
   children: ReactNode
@@ -8,35 +77,81 @@ interface Props {
   searchTerm: string
   [k: string]: any
 }
+
 const NameText = ({ children, employee, searchTerm, ...rest }: Props) => {
+  const [openEmployeeCard, setOpenEmployeeCard] = useState(false)
+  const handleOpenEmployeeCard = () => setOpenEmployeeCard(true)
+  const handleCloseEmployeeCard = () => setOpenEmployeeCard(false)
+
+  const employeeUrl = `${window.location.origin}/ansatt/${employee.email}`
+
+  const employeeProfile = useEmployeeProfile(employee.email)
+  const employeeImageUrl = employeeProfile.data?.image
+
   const theme = useTheme()
   const halo = theme.palette.background.paper // Stroke around the labels in case they overlap with a link
   const haloWidth = 0.2
 
   return (
-    <text
-      onClick={() =>
-        window.open(
-          `${window.location.origin}/ansatt/${employee.email}`,
-          `employee_${employee.email}`
-        )
-      }
-      style={{ cursor: 'hand' }}
-      stroke={halo}
-      strokeWidth={haloWidth}
-      paintOrder="stroke"
-      fill={theme.palette.text.primary}
-      opacity={
-        searchTerm.length < 0
-          ? 1
-          : employee.name.toLowerCase().includes(searchTerm)
-          ? 1
-          : 0.3
-      }
-      {...rest}
-    >
-      {children}
-    </text>
+    <>
+      <text
+        onClick={handleOpenEmployeeCard}
+        style={{ cursor: 'hand' }}
+        stroke={halo}
+        strokeWidth={haloWidth}
+        paintOrder="stroke"
+        fill={theme.palette.text.primary}
+        opacity={
+          searchTerm.length < 0
+            ? 1
+            : employee.name.toLowerCase().includes(searchTerm)
+            ? 1
+            : 0.3
+        }
+        {...rest}
+      >
+        {children}
+      </text>
+      <Modal open={openEmployeeCard} onClose={handleCloseEmployeeCard}>
+        <Box sx={style}>
+          <EmployeeCard sx={{ display: 'flex' }}>
+            <EmployeeCardName>{employee.name}</EmployeeCardName>
+            <EmployeeCardContent>
+              <EmployeeCardContentLeft>
+                <EmployeeCardField>
+                  <EmployeeCardFieldLabel>{'Tittel: '}</EmployeeCardFieldLabel>
+                  <EmployeeCardFieldValue>
+                    {employee.title ?? 'Ingen'}
+                  </EmployeeCardFieldValue>
+                </EmployeeCardField>
+                <EmployeeCardField>
+                  <EmployeeCardFieldLabel>
+                    {'Nærmeste leder: '}
+                  </EmployeeCardFieldLabel>
+                  <EmployeeCardFieldValue>
+                    {employee.manager}
+                  </EmployeeCardFieldValue>
+                </EmployeeCardField>
+              </EmployeeCardContentLeft>
+              <EmployeeCardContentRight>
+                <EmployeeCardImage src={employeeImageUrl} />
+                <Button
+                  fullWidth={true}
+                  href={employeeUrl}
+                  size="small"
+                  sx={{
+                    background: theme.palette.secondary.main,
+                    fontSize: 10,
+                  }}
+                >
+                  Gå til profil
+                </Button>
+              </EmployeeCardContentRight>
+            </EmployeeCardContent>
+          </EmployeeCard>
+        </Box>
+      </Modal>
+    </>
   )
 }
 

--- a/apps/web/src/pages/organizationStructure/Components/NameText.tsx
+++ b/apps/web/src/pages/organizationStructure/Components/NameText.tsx
@@ -21,11 +21,11 @@ const style = {
 const EmployeeCard = styled('div')({
   display: 'flex',
   flexDirection: 'column',
-  gap: 16,
+  gap: '1rem',
 })
 
 const EmployeeCardName = styled('div')({
-  fontSize: 20,
+  fontSize: '1.25rem',
   fontWeight: 600,
 })
 
@@ -33,7 +33,7 @@ const EmployeeCardContent = styled('div')({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',
-  gap: 16,
+  gap: '1rem',
   width: '100%',
 })
 
@@ -41,7 +41,7 @@ const EmployeeCardContentLeft = styled('div')({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'start',
-  gap: 8,
+  gap: '0.5rem',
   width: '65%',
 })
 
@@ -50,7 +50,7 @@ const EmployeeCardContentRight = styled('div')({
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: 16,
+  gap: '1rem',
   width: '35%',
 })
 
@@ -67,7 +67,7 @@ const EmployeeCardFieldLabel = styled('div')({
 const EmployeeCardFieldValue = styled('div')({})
 
 const EmployeeCardImage = styled('img')({
-  borderRadius: 90,
+  borderRadius: '50%',
   width: '100%',
 })
 


### PR DESCRIPTION
#### Hva har blitt løst?
I organisasjonsstrukturen var det ønsket at et kort med noe informasjon ble vist, med mulighet til å navigere til siden for den ansatte. For øyeblikket blir man sendt direkte til den ansatte sin siden dersom man trykker på navnet til personen.

#### Hvordan ble det løst?
For å style kortet har jeg tatt i bruk MUI sin styled() utility for å style componenter.
* Laget et styled component per inndeling av kortet.
* For å hente profilbildet bruker jeg hooken useEmployeeProfile() for å huke tak i bilde-url'en.

<img width="439" alt="Screenshot 2024-04-08 at 08 11 57" src="https://github.com/knowit/folk-webapp/assets/33129259/5a2282d5-9e18-40dc-b6c3-639bbd4410f9">
