### PR TITLE
[486] Matomo tracking oppdateringer

### DIFF
--- a/apps/web/src/components/Content.tsx
+++ b/apps/web/src/components/Content.tsx
@@ -1,4 +1,3 @@
-import React, { useEffect } from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import { isLoggedIn } from '../api/auth/authHelpers'
 import { useUserInfo } from '../context/UserInfoContext'
@@ -14,17 +13,9 @@ import {
   OrganizationStructurePage,
 } from '../pages'
 import LoginPage from '../pages/login/LoginPage'
-import { useMatomo } from '@jonkoops/matomo-tracker-react'
-import { useLocation } from 'react-router-dom'
 
 export default function Content() {
   const { user } = useUserInfo()
-  const { trackPageView } = useMatomo()
-  const location = useLocation()
-
-  useEffect(() => {
-    trackPageView()
-  }, [trackPageView, location.pathname])
 
   if (!isLoggedIn(user)) {
     return <LoginPage />

--- a/apps/web/src/components/charts/ChartDisplayOptions.tsx
+++ b/apps/web/src/components/charts/ChartDisplayOptions.tsx
@@ -34,6 +34,7 @@ interface ChartVariantToggleProps {
   selected: number
   onChange: (value: number) => void
   big?: boolean
+  title: string
 }
 
 export function ChartVariantToggle({
@@ -41,6 +42,7 @@ export function ChartVariantToggle({
   selected,
   onChange,
   big = false,
+  title,
 }: ChartVariantToggleProps) {
   const { trackEvent } = useMatomo()
 
@@ -48,7 +50,6 @@ export function ChartVariantToggle({
     event: React.MouseEvent,
     newChartIndex: number | null
   ) => {
-    trackEvent({ category: 'graf-type', action: 'click-event' })
     if (typeof newChartIndex === 'number') {
       onChange(newChartIndex)
     }
@@ -65,6 +66,17 @@ export function ChartVariantToggle({
         const { label, icon: ChartIcon } = chartVariantInfo[chartVariant.type]
         const buttonLabel = `Vis som ${label}`
 
+        const chartOptionChange = (label: string) => {
+          console.log(
+            `Tracked event: Changed chart variant to ${label} for ${title}`
+          )
+          trackEvent({
+            category: 'Graph type',
+            action: 'Changed graph type',
+            name: `Graph type changed to ${label} for ${title}`,
+          })
+        }
+
         return (
           <ToggleButton
             key={label}
@@ -72,6 +84,7 @@ export function ChartVariantToggle({
             disableRipple
             aria-label={buttonLabel}
             title={buttonLabel}
+            onClick={() => chartOptionChange(label)}
           >
             {ChartIcon}
           </ToggleButton>

--- a/apps/web/src/components/charts/ChartDisplayOptions.tsx
+++ b/apps/web/src/components/charts/ChartDisplayOptions.tsx
@@ -67,9 +67,6 @@ export function ChartVariantToggle({
         const buttonLabel = `Vis som ${label}`
 
         const chartOptionChange = (label: string) => {
-          console.log(
-            `Tracked event: Changed chart variant to ${label} for ${title}`
-          )
           trackEvent({
             category: 'Graph type',
             action: 'Changed graph type',

--- a/apps/web/src/components/charts/DropdownPicker.tsx
+++ b/apps/web/src/components/charts/DropdownPicker.tsx
@@ -10,6 +10,7 @@ interface DropdownPickerProps {
   onChange?: (newValue: any) => void
   selected?: any
   big?: boolean
+  title?: string
 }
 
 const ComponentRoot = styled(Select, {
@@ -66,6 +67,7 @@ export default function DropdownPicker({
   values,
   onChange = () => null,
   selected = '',
+  title,
   big,
 }: DropdownPickerProps) {
   const width =
@@ -86,7 +88,11 @@ export default function DropdownPicker({
       inputRef={selectRef}
       autoWidth
       onChange={({ target: { value } }) => {
-        trackEvent({ category: 'graf-datasett', action: 'click-event' })
+        trackEvent({
+          category: 'Graph category',
+          action: 'Dropdown category changed',
+          name: `Dropdown category changed to ${value} for ${title}`,
+        })
         return onChange(value)
       }}
       input={<InputBaseStyled />}

--- a/apps/web/src/components/charts/MultipleChartCard.tsx
+++ b/apps/web/src/components/charts/MultipleChartCard.tsx
@@ -51,6 +51,7 @@ const MultipleChartCard = ({
           values={groups.map((group) => group.name)}
           selected={selectedGroupName}
           onChange={setSelectedGroupName}
+          title={title}
         />
       </GridItemHeader>
 
@@ -65,11 +66,13 @@ const MultipleChartCard = ({
                 }))}
                 selected={selectedChartIndex}
                 onChange={setSelectedChartIndex}
+                title={title}
               />
             )}
 
             <ToggleBigChartButton
               big={isBig}
+              title={title}
               onChange={() => setIsBig(!isBig)}
             />
           </ChartDisplayOptions>

--- a/apps/web/src/components/charts/SingularChartCard.tsx
+++ b/apps/web/src/components/charts/SingularChartCard.tsx
@@ -63,6 +63,7 @@ const SingularChartCard = ({
           <ChartDisplayOptions>
             <ToggleBigChartButton
               big={isBig}
+              title={title}
               onChange={() => setIsBig(!isBig)}
             />
           </ChartDisplayOptions>

--- a/apps/web/src/components/charts/ToggleBigChartButton.tsx
+++ b/apps/web/src/components/charts/ToggleBigChartButton.tsx
@@ -29,15 +29,23 @@ const FullscreenExitIconStyled = styled(FullscreenExitIcon)(() => ({
 
 interface ToggleBigChartButtonProps {
   big: boolean
+  title: string
   onChange: () => void
 }
 
 export function ToggleBigChartButton({
   big,
+  title,
   onChange,
 }: ToggleBigChartButtonProps) {
   const { trackEvent } = useMatomo()
-  big && trackEvent({ category: 'graf-stor', action: 'click-event' })
+  big &&
+    trackEvent({
+      category: 'Graph size',
+      action: 'Changed graph size',
+      name: `Graph size changed expanded for ${title}`,
+    })
+
   const altText = big ? 'Lukk stor størrelse' : 'Utvid til stor størrelse'
 
   return (

--- a/apps/web/src/components/header/NavTab.tsx
+++ b/apps/web/src/components/header/NavTab.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Tab, Tabs } from '@mui/material'
 import { styled } from '@mui/material/styles'
 import { pageTitle } from '../../utils/pagetitle'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 interface NavTabContent {
   content: any
@@ -38,6 +39,7 @@ const getCurrentTabValue = () => {
 }
 
 export default function NavTab(props: NavTabProps) {
+  const { trackEvent } = useMatomo()
   const currentTabValue = getCurrentTabValue()
   const [value, setValue] = useState<number>(currentTabValue)
 
@@ -53,6 +55,13 @@ export default function NavTab(props: NavTabProps) {
         value={index}
         key={`navigation-tab-${content.title}`}
         label={content.title}
+        onClick={() => {
+          trackEvent({
+            category: 'customer-page-view',
+            action: 'tab-navigation',
+            name: `Show ${content.title}`,
+          })
+        }}
       />
     ))
   }

--- a/apps/web/src/components/header/NavTab.tsx
+++ b/apps/web/src/components/header/NavTab.tsx
@@ -57,9 +57,9 @@ export default function NavTab(props: NavTabProps) {
         label={content.title}
         onClick={() => {
           trackEvent({
-            category: 'customer-page-view',
-            action: 'tab-navigation',
-            name: `Show ${content.title}`,
+            category: 'On-Page tab navigation',
+            action: 'Switched view on page with tabs',
+            name: `Switched to ${content.title.toLowerCase} view`,
           })
         }}
       />

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -9,6 +9,8 @@ import { MatomoProvider, createInstance } from '@jonkoops/matomo-tracker-react'
 const instance = createInstance({
   urlBase: 'https://objectnet-dataplattform.matomo.cloud/',
   siteId: 1,
+  trackerUrl: 'https://objectnet-dataplattform.matomo.cloud/matomo.php',
+  srcUrl: 'https://objectnet-dataplattform.matomo.cloud/matomo.js',
   disabled: !process.env.NODE_ENV || process.env.NODE_ENV === 'development',
   heartBeat: {
     active: true, // optional, default value: true

--- a/apps/web/src/pages/competence/CompetencePage.tsx
+++ b/apps/web/src/pages/competence/CompetencePage.tsx
@@ -1,5 +1,5 @@
 import { Grid } from '@mui/material'
-import React from 'react'
+import { useEffect } from 'react'
 import {
   AgeDistributionCard,
   CompetenceAmountCard,
@@ -10,10 +10,17 @@ import {
   FagEventsCard,
   FagtimerCard,
 } from './cards'
-import { pageTitle } from '../../utils/pagetitle'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 export default function CompetencePage() {
-  pageTitle('Kompetanse')
+  const { trackPageView } = useMatomo()
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Kompetanse',
+    })
+  }, [])
+
   return (
     <Grid container spacing={2}>
       <CompetenceAmountCard />

--- a/apps/web/src/pages/competence/CompetencePage.tsx
+++ b/apps/web/src/pages/competence/CompetencePage.tsx
@@ -19,7 +19,7 @@ export default function CompetencePage() {
     trackPageView({
       documentTitle: 'Kompetanse',
     })
-  }, [])
+  }, [trackPageView])
 
   return (
     <Grid container spacing={2}>

--- a/apps/web/src/pages/customer/CustomerPage.tsx
+++ b/apps/web/src/pages/customer/CustomerPage.tsx
@@ -1,10 +1,17 @@
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 import NavTab from '../../components/header/NavTab'
 import CustomerList from './customer-list/CustomerList'
 import { CustomerOverview } from './customer-overview/CustomerOverview'
-import { pageTitle } from '../../utils/pagetitle'
+import { useEffect } from 'react'
 
 export default function Customer() {
-  pageTitle('Kunder')
+  const { trackPageView } = useMatomo()
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Kunder',
+    })
+  }, [])
 
   return (
     <NavTab

--- a/apps/web/src/pages/customer/CustomerPage.tsx
+++ b/apps/web/src/pages/customer/CustomerPage.tsx
@@ -11,7 +11,7 @@ export default function Customer() {
     trackPageView({
       documentTitle: 'Kunder',
     })
-  }, [])
+  }, [trackPageView])
 
   return (
     <NavTab

--- a/apps/web/src/pages/customer/CustomerSitePage.tsx
+++ b/apps/web/src/pages/customer/CustomerSitePage.tsx
@@ -1,9 +1,18 @@
 import { useParams } from 'react-router-dom'
 import { CustomerSiteContent } from './components/CustomerSiteContent'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
+import { useEffect } from 'react'
 
 export default function CustomerSite() {
+  const { trackPageView } = useMatomo()
   const routeParameters = useParams()
   const customerId = routeParameters.id
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: `Customer - ${customerId}`,
+    })
+  })
 
   return <CustomerSiteContent customerId={customerId} />
 }

--- a/apps/web/src/pages/customer/cards/HoursBilledPerWeekChart.tsx
+++ b/apps/web/src/pages/customer/cards/HoursBilledPerWeekChart.tsx
@@ -54,7 +54,12 @@ const HoursBilledPerWeekChart = ({
     : selectedCustomerIds.filter((sc) => customersWithConsultants.includes(sc))
 
   const setDateRange = (startDate, endDate) => {
-    trackEvent({ category: 'filter-dato', action: 'click-event' })
+    trackEvent({
+      category: 'Billing period',
+      action: 'Period set with DatePicker',
+      name: 'Customer overview graph date period set',
+    })
+
     setStartDate(startDate)
     setEndDate(endDate)
   }
@@ -101,6 +106,18 @@ const HoursBilledPerWeekChart = ({
     return index >= 0 ? index : 0
   }
 
+  function handleRadioButtonChange(event: React.ChangeEvent<HTMLInputElement>) {
+    const option = Object.keys(ChartPeriod).find(
+      (option) => option === event.target.value
+    )
+    trackEvent({
+      category: 'Billing period',
+      action: 'Period change by radio button',
+      name: `${eventNavn} by ${option.toLowerCase()}`,
+    })
+    setSelectedChartPeriod(ChartPeriod[option])
+  }
+
   const startIdx = startDate
     ? getStartIndex(filteredData?.data[0]?.data, startDate, (a, b) => a - b + 1)
     : 0
@@ -121,8 +138,13 @@ const HoursBilledPerWeekChart = ({
         }
 
   const eventNavn = specificCustomer
-    ? 'fakturerte-timer-kunde'
-    : 'fakturerte-timer'
+    ? 'Billed hours for customer'
+    : 'Billed hours'
+
+  const noDataText = specificCustomer
+    ? 'Manglende timelistedata for gitt kunde'
+    : 'Bruk listen til høyre for å velge hvilke kunder du vil vise i grafen'
+
   return (
     <ChartCard
       title={'Timer brukt per periode'}
@@ -130,11 +152,7 @@ const HoursBilledPerWeekChart = ({
       data={timeFilteredData}
       error={error}
       fullSize={true}
-      noDataText={
-        specificCustomer
-          ? 'Manglende timelistedata for gitt kunde'
-          : 'Bruk listen til høyre for å velge hvilke kunder du vil vise i grafen'
-      }
+      noDataText={noDataText}
       legendWidth={specificCustomer ? 400 : undefined}
       sliceTooltip={HoursBilledPerWeekTooltip}
       extraHeaderContent={
@@ -146,14 +164,7 @@ const HoursBilledPerWeekChart = ({
               row
               value={selectedChartPeriod}
               onChange={(event) => {
-                const option = Object.keys(ChartPeriod).find(
-                  (option) => option === event.target.value
-                )
-                trackEvent({
-                  category: `${eventNavn}-${option.toLowerCase()}`,
-                  action: 'click-event',
-                })
-                setSelectedChartPeriod(ChartPeriod[option])
+                handleRadioButtonChange(event)
               }}
             >
               {Object.keys(ChartPeriod).map((option: ChartPeriod) => (

--- a/apps/web/src/pages/customer/customer-list/CustomerList.tsx
+++ b/apps/web/src/pages/customer/customer-list/CustomerList.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Box } from '@mui/material'
 import { BaseSkeleton } from '../../../components/skeletons/BaseSkeleton'
 import { GridItem } from '../../../components/gridItem/GridItem'
@@ -15,6 +14,7 @@ import { FallbackMessage } from '../../employee/components/FallbackMessage'
 import { ArrowDownward, ArrowUpward } from '@mui/icons-material'
 import { styled } from '@mui/material/styles'
 import { getEmployeeForCustomerSearchableColumns } from '../../employee/table/SortableEmployeeTable'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 enum ColumnName {
   KUNDE = 'KUNDE',
@@ -24,13 +24,13 @@ enum ColumnName {
 
 export default function CustomerList() {
   const customerCards = useCustomerCards()
+  const { trackEvent } = useMatomo()
   const [searchTerm, setSearchTerm] = useState('')
   const { data, error } = useEmployeesByCustomer()
   const isLoading = !data
   const [sortColumn, setSortColumn] = useState(ColumnName.KUNDE)
-  const [sortOrder, setSortOrder] = React.useState<'ASC' | 'DESC'>('ASC')
-
-  const memoizedData = React.useMemo(() => {
+  const [sortOrder, setSortOrder] = useState<'ASC' | 'DESC'>('ASC')
+  const memoizedData = useMemo(() => {
     if (!data) return []
     return data.map((customer) => {
       return {
@@ -78,6 +78,7 @@ export default function CustomerList() {
       const accountManagerB =
         customerCards.find((cc) => cc.customer === b.customer_name)
           ?.accountManager || 'å'
+
       switch (sortColumn) {
         case ColumnName.KUNDE:
           return a.customer_name.localeCompare(b.customer_name, 'no', {
@@ -110,6 +111,12 @@ export default function CustomerList() {
     }
   }
   const switchSort = (columnName: ColumnName) => {
+    trackEvent({
+      category: 'Sorting',
+      action: 'Customer list column name clicked',
+      name: `Sorted customer list on ${columnName.toLowerCase()}`,
+    })
+
     if (sortColumn === columnName) {
       setSortOrder(sortOrder === 'ASC' ? 'DESC' : 'ASC')
     } else {

--- a/apps/web/src/pages/customer/customer-overview/CustomerCardSort.tsx
+++ b/apps/web/src/pages/customer/customer-overview/CustomerCardSort.tsx
@@ -54,9 +54,11 @@ const CustomerCardSort = ({
 
   const changeSortType = (type: string) => {
     trackEvent({
-      category: `sortering-kunder-${type.replace(/\s/g, '').toLowerCase()}`,
-      action: 'click-event',
+      category: 'Sorting',
+      action: 'Changed customer sorting by button',
+      name: `Sorting by ${type.toLowerCase()}`,
     })
+
     if (activeSortButton === type) {
       const newOrder = sortOrder == 'ASC' ? 'DESC' : 'ASC'
       setSortOrder(newOrder)

--- a/apps/web/src/pages/customer/customer-overview/CustomerHoursPerWeekSection.tsx
+++ b/apps/web/src/pages/customer/customer-overview/CustomerHoursPerWeekSection.tsx
@@ -14,6 +14,7 @@ import { FormControlLabel, Radio, RadioGroup } from '@mui/material'
 import { Dispatch, SetStateAction, useState } from 'react'
 import { Translation } from '../../../utils/translation'
 import useChartData from '../../../components/charts/chartFilters/useChartData'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 interface HoursBilledPerWeekCardProps {
   selectedCustomerIds: string[]
@@ -37,12 +38,12 @@ const CustomerHoursPerWeekSection = ({
   selectedChartPeriod,
   setSelectedChartPeriod,
 }: HoursBilledPerWeekCardProps) => {
+  const { trackEvent } = useMatomo()
   const [selectedSortMethod, setSelectedSortMethod] = useState(SortMethod.abc)
   const customersWithConsultants = useCustomerCards()
     .filter((cc) => cc.consultantsLastPeriod > 0)
     .map((customerCard) => customerCard.customer)
   const { data } = useHoursBilledPerWeekCharts()
-
   const chartData = useChartData(data, selectedChartPeriod)
 
   const customerIdsUnfiltered =
@@ -55,9 +56,22 @@ const CustomerHoursPerWeekSection = ({
   )
 
   const handleSelectAll = () => {
+    trackEvent({
+      category: 'Filtering',
+      action: `Filtered customers by using "Select All" checkbox`,
+      name: 'Filter by selecting all',
+    })
+
     setSelectedCustomerIds(customers.sort())
   }
+
   const handleSelectNone = () => {
+    trackEvent({
+      category: 'Filtering',
+      action: `Filtered customers by using "Deselect all" checkbox`,
+      name: 'Filter by deselecting all',
+    })
+
     setSelectedCustomerIds([])
   }
 
@@ -78,6 +92,16 @@ const CustomerHoursPerWeekSection = ({
   }
 
   function toggleShowHistoricCustomer() {
+    trackEvent({
+      category: 'Filtering',
+      action: `Filtered customers by using "Historic customers" checkbox`,
+      name: `Filter by ${
+        !showCustomerHistory
+          ? 'including historic customers'
+          : 'removing historic customers'
+      }`,
+    })
+
     setShowCustomerHistory(!showCustomerHistory)
 
     if (selectAll.checked === true) {

--- a/apps/web/src/pages/employee/EmployeePage.tsx
+++ b/apps/web/src/pages/employee/EmployeePage.tsx
@@ -1,9 +1,17 @@
 import { Grid } from '@mui/material'
 import { EmployeeTable } from './table/EmployeeTable'
-import { pageTitle } from '../../utils/pagetitle'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
+import { useEffect } from 'react'
 
 export default function EmployeePage() {
-  pageTitle('Ansatte')
+  const { trackPageView } = useMatomo()
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Ansatte',
+    })
+  }, [])
+
   return (
     <Grid container spacing={2}>
       <EmployeeTable />

--- a/apps/web/src/pages/employee/EmployeePage.tsx
+++ b/apps/web/src/pages/employee/EmployeePage.tsx
@@ -10,7 +10,7 @@ export default function EmployeePage() {
     trackPageView({
       documentTitle: 'Ansatte',
     })
-  }, [])
+  }, [trackPageView])
 
   return (
     <Grid container spacing={2}>

--- a/apps/web/src/pages/employee/EmployeeProfilePage.tsx
+++ b/apps/web/src/pages/employee/EmployeeProfilePage.tsx
@@ -2,13 +2,22 @@ import * as React from 'react'
 import { useParams } from 'react-router-dom'
 import { EmployeeProfileContent } from './components/EmployeeProfileContent'
 import { EmployeeNotFound } from './components/EmployeeNotFound'
+import { useEffect } from 'react'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 // We might have to create better validation if IDs should be more flexible
 const validEmailRegex = /^[\w.-]+@knowit.no$/
 
 export default function EmployeeProfile() {
+  const { trackPageView } = useMatomo()
   const routeParameters = useParams()
   const employeeEmail = routeParameters.id ?? ''
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: `Employee - ${employeeEmail}`,
+    })
+  })
 
   const isValidId = employeeEmail.match(validEmailRegex)
 

--- a/apps/web/src/pages/employee/table/EmployeeTableWithFilter.tsx
+++ b/apps/web/src/pages/employee/table/EmployeeTableWithFilter.tsx
@@ -24,6 +24,7 @@ import { Paper } from '@mui/material'
 import { RowCount } from '../../../components/sortableTable/RowCount'
 import { FilteredDownloadCell } from '../../../components/sortableTable/DataCells'
 import { statusDisplayDetails } from '../../../components/sortableTable/cells/ProjectStatusCell'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 export interface SearchableColumn {
   columnIndex: number
@@ -46,8 +47,17 @@ export default function EmployeeTableWithFilter({
   const [filters, setFilters] = useState<FilterObject[]>(initialFilters)
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [displayNonProject, setDisplayNonProject] = useState(false)
+  const { trackEvent } = useMatomo()
 
   function toggleDisplayNonProject() {
+    if (!displayNonProject) {
+      trackEvent({
+        category: 'Filtering',
+        action: 'Filtered employees by only showing free ones',
+        name: `Filter by only showing free employees`,
+      })
+    }
+
     setDisplayNonProject(!displayNonProject)
   }
 

--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -1,13 +1,20 @@
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 import { Button } from '@mui/material'
-import { pageTitle } from '../../utils/pagetitle'
+import { useEffect } from 'react'
 
 const LoginPage = () => {
+  const { trackPageView } = useMatomo()
+
   const onClickHandler = () => {
     console.log('clicked')
     window.location.replace('/auth/login')
   }
 
-  pageTitle('Login')
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Login',
+    })
+  })
 
   return (
     <div>

--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -6,7 +6,6 @@ const LoginPage = () => {
   const { trackPageView } = useMatomo()
 
   const onClickHandler = () => {
-    console.log('clicked')
     window.location.replace('/auth/login')
   }
 

--- a/apps/web/src/pages/organizationStructure/OrganizationStructurePage.tsx
+++ b/apps/web/src/pages/organizationStructure/OrganizationStructurePage.tsx
@@ -2,20 +2,25 @@ import { useEmployeeStructure } from '../../api/data/employee/employeeQueries'
 import OrganizationStructureTree from './Components/OrganizationStructureTree'
 import { BaseSkeleton } from '../../components/skeletons/BaseSkeleton'
 import { FallbackMessage } from '../employee/components/FallbackMessage'
-import { pageTitle } from '../../utils/pagetitle'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Filter from './Components/Filter/Filter'
 import styled from '@emotion/styled'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 export default function OrganizationStructurePage() {
+  const { trackPageView } = useMatomo()
   const { data, isLoading, error } = useEmployeeStructure()
   const [hideChildNodes, setHideChildNodes] = useState(false)
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Organisasjonsstruktur',
+    })
+  }, [])
 
   function toggleEmployees() {
     setHideChildNodes(!hideChildNodes)
   }
-
-  pageTitle('Organisasjonsstruktur')
 
   if (isLoading) {
     return (

--- a/apps/web/src/pages/organizationStructure/OrganizationStructurePage.tsx
+++ b/apps/web/src/pages/organizationStructure/OrganizationStructurePage.tsx
@@ -16,7 +16,7 @@ export default function OrganizationStructurePage() {
     trackPageView({
       documentTitle: 'Organisasjonsstruktur',
     })
-  }, [])
+  }, [trackPageView])
 
   function toggleEmployees() {
     setHideChildNodes(!hideChildNodes)

--- a/apps/web/src/pages/other/DebugPage.tsx
+++ b/apps/web/src/pages/other/DebugPage.tsx
@@ -1,8 +1,15 @@
-import React from 'react'
-import { pageTitle } from '../../utils/pagetitle'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
+import { useEffect } from 'react'
 
 const Debug = () => {
-  pageTitle('Debug')
+  const { trackPageView } = useMatomo()
+
+  useEffect(() => {
+    trackPageView({
+      documentTitle: 'Debug',
+    })
+  })
+
   return <div>buggin</div>
 }
 

--- a/apps/web/src/pages/other/UnderConstructionPage.tsx
+++ b/apps/web/src/pages/other/UnderConstructionPage.tsx
@@ -1,12 +1,17 @@
-import React from 'react'
+import { useEffect } from 'react'
 import { Typography, Box } from '@mui/material'
 import { useLocation } from 'react-router-dom'
-import { pageTitle } from '../../utils/pagetitle'
+import { useMatomo } from '@jonkoops/matomo-tracker-react'
 
 export default function UnderConstruction() {
   const location = useLocation()
+  const { trackPageView } = useMatomo()
 
-  pageTitle(location.pathname.split('/')[1])
+  useEffect(() => {
+    trackPageView({
+      documentTitle: `${location.pathname.split('/')[1]}`,
+    })
+  })
 
   return (
     <Box justifyContent="center">


### PR DESCRIPTION
#### Hva løser oppgaven:
Skal forbedre Matomo dashboards og ha flere muligheter til å lage egne _custom reports_ som kan brukes i dashboardet.


#### Hvordan er oppgaven løst:
* Oppdatert tracking av besøk på sider. Kodesnutten som tracker siden blir gjort på den spesifikke siden, i stedet for å ha koden et sted som håndterer det for alle sidetyper. Dette har jeg gjort for å åpne opp for egendefinerte verdier i trackingen og gi nye utviklere en synligere kobling til Matomo slik at det blir enklere for dem å huske at de også må forholde seg til det.
* Lagt til flere events som blir tracket bl. a: klikk for å endre visningen på _Kunder_-siden, klikk for å filtrere og sortere tabeller eller lister.
* Noen av trackerne tar i bruk _titles_ og _labels_ som de var via props for å ha mer detaljer i noen av trackerne.