### PR TITLE
[Fix] Fikset feil verdi på navn til en tracket handling

### DIFF
--- a/apps/web/src/components/header/NavTab.tsx
+++ b/apps/web/src/components/header/NavTab.tsx
@@ -59,7 +59,7 @@ export default function NavTab(props: NavTabProps) {
           trackEvent({
             category: 'On-Page tab navigation',
             action: 'Switched view on page with tabs',
-            name: `Switched to ${content.title.toLowerCase} view`,
+            name: `Switched to ${content.title.toLowerCase()} view`,
           })
         }}
       />


### PR DESCRIPTION
#### Hva løser oppgaven:
Navnet som ble gitt til en tracket event i Matomo manglet `()` på slutten, som gjorde at variabelen i teksten ble tolket som en funksjon i stedet for resultatet av funksjonen.

<img width="602" alt="Screenshot 2024-05-14 at 11 39 02" src="https://github.com/knowit/folk-webapp/assets/33129259/5362c5d3-d671-42b3-bb09-00a86914e72d">

#### Hvordan er oppgaven løst:
* La inn `()` bak metodenavnet