### PR TITLE
Changed redirect url to include all possible redirect urls for the app

### DIFF
--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -5,14 +5,16 @@ const config = {
     login: {
       OAUTH_DOMAIN: process.env.REACT_APP_OAUTH_DOMAIN,
       OAUTH_SCOPES: ['email', 'openid', 'profile'],
-      OAUTH_REDIRECT_SIGNIN:
-        process.env.NODE_ENV === 'production'
-          ? ['https://folk.knowit.no/']
-          : ['https://localhost:3000/', 'https://dev.folk.knowit.no/'],
-      OAUTH_REDIRECT_SIGNOUT:
-        process.env.NODE_ENV === 'production'
-          ? ['https://folk.knowit.no/']
-          : ['https://localhost:3000/', 'https://dev.folk.knowit.no/'],
+      OAUTH_REDIRECT_SIGNIN: [
+        'https://localhost:3000/',
+        'https://dev.folk.knowit.no/',
+        'https://folk.knowit.no/',
+      ],
+      OAUTH_REDIRECT_SIGNOUT: [
+        'https://localhost:3000/',
+        'https://dev.folk.knowit.no/',
+        'https://folk.knowit.no/',
+      ],
     },
   },
   matomo: {


### PR DESCRIPTION
#### Hva løser oppgaven:
Får feilmelding om at Amplify Auth ikke er konfigurert. Tror muligens dette skyldes krøll med redirect URLene som settes gjennom en `NODE_ENV` sjekk,

<img width="528" alt="Feilmelding fra Amplify Auth" src="https://github.com/knowit/folk-webapp/assets/33129259/41ac1bb7-9413-4faa-9f54-3beec2ca1e89">

#### Hvordan er oppgaven løst:
Inkluderer alle mulige redirect URLer, som ser ut til å fungere lokalt. 
