### PR TITLE
[Fix] Opprette AD pålogging

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -61,11 +61,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add Cognito variables to .env file
-        working-directory: apps/web
         run: |
-          echo "REACT_APP_APP_CLIENT_ID=$COGNITO_APP_CLIENT_ID" >> .env
-          echo "REACT_APP_APP_OAUTH_DOMAIN=$COGNITO_APP_OAUTH_DOMAIN" >> .env
-          echo "REACT_APP_APP_USER_POOL_ID=$COGNITO_USER_POOL_ID" >> .env
+          echo "REACT_APP_APP_CLIENT_ID=$COGNITO_APP_CLIENT_ID" >> apps/web/.env
+          echo "REACT_APP_APP_OAUTH_DOMAIN=$COGNITO_APP_OAUTH_DOMAIN" >> apps/web/.env
+          echo "REACT_APP_APP_USER_POOL_ID=$COGNITO_USER_POOL_ID" >> apps/web/.env
       - name: Build web
         working-directory: apps/web
         run: yarn predeploy:dev

--- a/apps/web/src/index.tsx
+++ b/apps/web/src/index.tsx
@@ -26,6 +26,8 @@ const instance = createInstance({
   },
 })
 
+console.log('AppClientID:', process.env.REACT_APP_APP_CLIENT_ID)
+
 Amplify.configure({
   Auth: {
     Cognito: {


### PR DESCRIPTION
#### Hva løser oppgaven:
Forsøk på å løse feilmeldingen fra Amplify Auth konfigurasjonen.

<img width="533" alt="Amplify Auth feilmelding" src="https://github.com/knowit/folk-webapp/assets/33129259/cc9ba9f2-44a6-490c-abf0-e047d02a7de2">

#### Hvordan er oppgaven løst:
* Forsøker å sette variablene i .env direkte i skriptet, i stedet for å bruke working-directory. Dvs. legge til `apps/web` før `.env`
* Legger til en console log for debugging. Skal brukes til å dobbeltsjekke at variabelen er satt før konfigurasjonen. Skal slettes.