### PR TITLE
Fix/574 correct color order for linechart

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ In addition to the two `apps`, there are `packages` containing shared code and c
 
 Before first launch, or whenever dependencies are changed, run the `yarn install` command _in the root_ of the project. That will bootstrap and [hoist](https://developer.mozilla.org/en-US/docs/Glossary/Hoisting) all the dependencies.
 
+It is also necessary to add a variable to the _.env_ file under _**./apps/web**_.
+
+- `REACT_APP_ENV=development`
+
 When developing locally, there are two options on how to run the application:
 
 ### Option A: running both server and web locally

--- a/apps/web/src/components/charts/nivo/LineChart.tsx
+++ b/apps/web/src/components/charts/nivo/LineChart.tsx
@@ -67,12 +67,12 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
   }, [colorMap])
 
   useEffect(() => {
-    series.forEach((s) => {
-      if (!colorMap[s.id]) {
+    for (let i = series.length - 1; i >= 0; i--) {
+      if (!colorMap[series[i].id]) {
         const c = getNextColor()
-        setColorMap({ ...colorMap, [s.id]: c })
+        setColorMap({ ...colorMap, [series[i].id]: c })
       }
-    })
+    }
   }, [series, colorMap, getNextColor])
 
   const rows = Math.ceil(series.length / perRow)
@@ -143,7 +143,7 @@ const LineChart: React.FC<LineSvgProps & IsBigProps> = ({
                   style={{
                     width: '12px',
                     height: '12px',
-                    backgroundColor: value.serieColor,
+                    backgroundColor: colorMap[value.serieId],
                     display: 'inline-block',
                     margin: '5px',
                   }}

--- a/apps/web/src/pages/competence/cards/FagtimerCard.tsx
+++ b/apps/web/src/pages/competence/cards/FagtimerCard.tsx
@@ -7,7 +7,7 @@ const FagtimerCard = () => {
   return (
     <ChartCard
       title="Aktivitet faggrupper"
-      description="Hver vertikal akse viser antall unike fag aktiviteter per uke, deulike linjene representerer de ulike årene"
+      description="Hver vertikal akse viser antall unike fag aktiviteter per uke, de ulike linjene representerer de ulike årene"
       data={data}
       legendWidth={100}
       error={error}


### PR DESCRIPTION
Legend under _Aktivitet faggrupper_ på _Kompetanse_-siden gir farger til årstallene i feil rekkefølge, slik at fargene ikke stemmer med diagrammets farger.

Fiks:
-Reverserer loopen som delegerer farger til årstallene
(Tror egentlig ikke dette er beste løsning, men det fikser problemet)

Komponenten brukes også av _Timer brukt per periode_ under _Overordnet oversikt_ på _Kunder_-siden, men fiksen skal ikke ødelegge for dette diagrammet.