### PR TITLE
[597-Fix] Profilbilde i header

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Launch Chrome against localhost",
       "url": "https://localhost:3000",
-      "webRoot": "${workspaceFolder}/apps/website"
+      "webRoot": "${workspaceFolder}/apps/web"
     }
   ]
 }

--- a/apps/web/src/context/UserInfoContext.tsx
+++ b/apps/web/src/context/UserInfoContext.tsx
@@ -25,31 +25,22 @@ const UserInfoProvider: React.FC<{ children: React.ReactNode }> = ({
       try {
         const user = await getUserInfo()
         setUserInfo(user)
+
+        if (user) {
+          const userEmail = user.email?.toLowerCase()
+          const employeeProfile = await getEmployeeProfile(userEmail)
+          setUserEmployeeProfile(employeeProfile)
+        }
       } catch (error) {
         if (isError(error)) {
           setUserInfo(null)
+          setUserEmployeeProfile(null)
         }
       }
     }
 
     fetchUser()
   }, [])
-
-  useEffect(() => {
-    async function fetchEmployeeProfile() {
-      if (userInfo) {
-        const userEmail = userInfo.email?.toLowerCase()
-        if (userEmail) {
-          const data = await getEmployeeProfile(userEmail)
-          setUserEmployeeProfile(data)
-        }
-      } else {
-        setUserEmployeeProfile(null)
-      }
-    }
-
-    fetchEmployeeProfile()
-  }, [userInfo])
 
   return (
     <UserInfoContext.Provider

--- a/apps/web/src/context/UserInfoContext.tsx
+++ b/apps/web/src/context/UserInfoContext.tsx
@@ -28,8 +28,10 @@ const UserInfoProvider: React.FC<{ children: React.ReactNode }> = ({
 
         if (user) {
           const userEmail = user.email?.toLowerCase()
-          const employeeProfile = await getEmployeeProfile(userEmail)
-          setUserEmployeeProfile(employeeProfile)
+          if (userEmail) {
+            const employeeProfile = await getEmployeeProfile(userEmail)
+            setUserEmployeeProfile(employeeProfile)
+          }
         }
       } catch (error) {
         if (isError(error)) {


### PR DESCRIPTION
#### Hva løser oppgaven:
I produksjon ble ikke profilbildet til den innloggede brukeren hentet.

#### Hvordan er oppgaven løst:
* Henter employeeProfile-data i den samme useEffecten som userInfo blir hentet, i stedet for å håndteres det i to ulike useEffects. Unødvendig når den ene useEffecten er avhengig av resultatet fra kallet som henter userInfo.
* Også oppdatert launch.json, fordi webRoot definert der var feil.