### PR TITLE
#580: Navn på ansatte i listevisningen under Kunder

### DIFF
--- a/apps/server/routers/customer/customerAggregation.ts
+++ b/apps/server/routers/customer/customerAggregation.ts
@@ -39,7 +39,7 @@ async function createEmployeeForCustomerList(
     rowId: employee.email,
     rowData: [
       {
-        name: employee.navn,
+        name: employee.name,
         email: employee.email,
         image_url: await getStorageUrl(employee.image_key),
         user_id: employee.user_id,

--- a/apps/server/routers/customer/customerTypes.ts
+++ b/apps/server/routers/customer/customerTypes.ts
@@ -12,7 +12,7 @@ export interface BilledCustomerHours {
 export interface EmployeeWithPrimaryCustomer {
   user_id: string
   guid: string
-  navn: string
+  name: string
   title?: string
   link: string
   email: string


### PR DESCRIPTION
Issue: [#580](https://github.com/orgs/knowit/projects/9/views/1?pane=issue&itemId=66397785)

I listevisningen under 'Kunder' på nettsiden dukker det ikke opp navn på konsulenter som jobber hos en kunde.

Fix: JSON-filen fra AWS bruker 'name', ikke 'navn' for navn på ansatte, så bruk av 'navn' i frontend-koden har vært en bug som nå blir rettet opp.