### PR TITLE
[Fix] 600 Filtrere bort de som ikke har begynt å jobbe

### DIFF
--- a/apps/server/routers/employees/employeesAggregation.ts
+++ b/apps/server/routers/employees/employeesAggregation.ts
@@ -37,7 +37,7 @@ export const aggregateEmployeeTable = async (
   const filteredBasicEmployeeInformation = basicEmployeeInformation.filter(
     (employee) => {
       const startDate = getStartDate(employee, employee_experience)
-      return Date.parse(startDate) <= Date.now()
+      return startDate == null || Date.parse(startDate) <= Date.now()
     }
   )
 


### PR DESCRIPTION
#### Hva løser oppgaven:
Når de ansatte skal filtreres på startdato, brukes en rapport for filtreringen. I denne rapporten er det ikke alle ansatte er i, pga diverse, som gjør at de forsvinner i filtreringen selv om de ikke skal det.

#### Hvordan er oppgaven løst:
Sjekker om filtreringsfunksjonen returnerer null. Dersom den gjør det, tas fortsatt den ansatte med i listen som vises på forsiden. De som har en fremtidig sluttdato blir da ikke med i listen, og så må de som evt har sluttet med fortsatt står på listen vente til AD/Simployer har håndtert det hos seg.