### PR TITLE
Turn off some eslint-warnings

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -39,6 +39,8 @@ export default [
       'react/jsx-key': 'warn',
       '@typescript-eslint/no-require-imports': 'warn',
       'no-undef': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'off',
+      '@typescript-eslint/explicit-module-boundary-types': 'off',
     },
   },
 ]


### PR DESCRIPTION
Alle api-kallene i web klager over manglende retur-typer, slår av eslint-warnings for disse