### PR TITLE
Temp python backend intermediary for KnowitGPT

### DIFF
--- a/apps/server/implementations/azure-openai-llm-repository-impl.ts
+++ b/apps/server/implementations/azure-openai-llm-repository-impl.ts
@@ -34,7 +34,7 @@ export class AzureOpenAILLMRepositoryImpl extends LLMClient {
     model: string,
     messages: LLMMessage[],
     tools?: Tool[],
-    options?: Record<string, any>
+    options?: Record<string, never>
   ): Promise<LLMResponse> {
     try {
       const response: ChatCompletion =
@@ -81,7 +81,7 @@ export class AzureOpenAILLMRepositoryImpl extends LLMClient {
     model: string,
     messages: LLMMessage[],
     tools?: Tool[],
-    options?: Record<string, any>
+    options?: Record<string, never>
   ): AsyncGenerator<LLMChunk> {
     try {
       // Make the API call
@@ -105,7 +105,7 @@ export class AzureOpenAILLMRepositoryImpl extends LLMClient {
     model: string,
     messages: LLMMessage[],
     tools?: Tool[],
-    options?: Record<string, any>
+    options?: Record<string, never>
   ): AsyncGenerator<LLMChunk> {
     let toolCallingChunk: ChatCompletionChunk
     for await (const output of stream) {

--- a/apps/server/implementations/python_app-llm-repository-impl.ts
+++ b/apps/server/implementations/python_app-llm-repository-impl.ts
@@ -1,0 +1,120 @@
+import {
+  LLMChunk,
+  LLMClient,
+  LLMMessage,
+  LLMResponse,
+  Tool,
+} from '../repository/llm-repository'
+import fetch from 'node-fetch'
+
+/*
+Quick implementation for out LLMClient to communicate with a intermediary python endpoint that handles all pre- and
+post processing of prompt and messages, to better facilitate data storage in DataBricks so that we can easier 
+optimize and evaluate MLFlow
+*/
+export class PythonAppLLMClientImpl extends LLMClient {
+  // TODO: Test and verify endpoint with actual values and interject it into the KnowitGPT pipeline. This is only scaffolding.
+  constructor(endpoint: string) {
+    super()
+    this.endpoint = endpoint
+  }
+
+  endpoint: string
+
+  async generateReply(
+    model: string,
+    messages: LLMMessage[],
+    tools?: Tool[],
+    options?: Record<string, never>
+  ): Promise<LLMResponse> {
+    // Build your request payload
+    const payload = {
+      model,
+      messages,
+      tools,
+      ...options,
+    }
+
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload), // JSONify the payload
+      })
+
+      if (!response.ok) {
+        // You can throw a custom error or handle non-2xx statuses here
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+
+      // Parse the JSON response
+      const data: LLMResponse = await response.json()
+      return data
+    } catch (error) {
+      // Handle fetch/connection errors here
+      throw new Error(`Failed to generate reply: ${error}`)
+    }
+  }
+
+  async *generateStream(
+    model: string,
+    messages: LLMMessage[],
+    tools?: Tool[],
+    options?: Record<string, never>
+  ): AsyncGenerator<LLMChunk> {
+    const payload = {
+      model,
+      messages,
+      tools,
+      ...options,
+    }
+
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload), // JSONify the payload
+    })
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`)
+    }
+
+    const nodeStream = response.body
+    if (!nodeStream) {
+      throw new Error('No response body')
+    }
+
+    const decoder = new TextDecoder()
+    let bufferedText = ''
+
+    for await (const chunk of nodeStream) {
+      // Narrow down the type:
+      if (typeof chunk === 'string') {
+        // If it’s already a string, just append it
+        bufferedText += chunk
+      } else {
+        // Otherwise, assume it’s a Buffer/Uint8Array and decode it
+        bufferedText += decoder.decode(chunk)
+      }
+
+      // Split on newlines for NDJSON
+      const lines = bufferedText.split('\n')
+      for (let i = 0; i < lines.length - 1; i++) {
+        const line = lines[i].trim()
+        if (line) {
+          yield JSON.parse(line)
+        }
+      }
+      bufferedText = lines[lines.length - 1]
+    }
+
+    // Handle leftover text
+    if (bufferedText.trim()) {
+      yield JSON.parse(bufferedText.trim())
+    }
+  }
+}

--- a/apps/server/repository/llm-repository.ts
+++ b/apps/server/repository/llm-repository.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 // Interface for a generic LLM so we can quickly adapt to changes with differing implementations
 export abstract class LLMClient {
   /*
@@ -43,11 +44,13 @@ export abstract class LLMClient {
   Returns:
     A list of embedded chunks
   */
-  abstract generateEmbedding(
+  async generateEmbedding(
     embeddingModel: string,
     chunks: string[],
     options?: Record<string, any>
-  ): Promise<ChunkEmbedding[]>
+  ): Promise<ChunkEmbedding[]> {
+    throw new Error('Method not implemented.')
+  }
 }
 export interface ChunkEmbedding {
   chunk: string

--- a/apps/web/src/api/data/llm/llmQueries.ts
+++ b/apps/web/src/api/data/llm/llmQueries.ts
@@ -24,15 +24,15 @@ export const useGenerateLLMStream = (messages: LLMMessage[]) => {
     setError(null)
     setIsLoading(true)
 
-    const handleChunk = (chunk: LLMChunk) => {
+    function handleChunk(chunk: LLMChunk): void {
       setChunks((prevChunks) => [...prevChunks, chunk]) // Add chunk to state
     }
 
-    const handleDone = () => {
+    function handleDone(): void {
       setIsLoading(false) // Mark as not loading when done
     }
 
-    const handleError = (err: any) => {
+    function handleError(err: any): void {
       setError(err)
       setIsLoading(false)
     }
@@ -40,7 +40,7 @@ export const useGenerateLLMStream = (messages: LLMMessage[]) => {
     generateStream(messages, handleChunk, handleDone, handleError)
 
     // Clean-up logic in case the component unmounts
-    return () => {
+    return function (): void {
       // If needed, you can disconnect the socket or cancel the operation here
     }
   }, [messages])


### PR DESCRIPTION
**What does PR do**
* Adds a simple implementation of LLMClient that interfaces another endpoint
* This is in order for that endpoint (a proposed python backend) should handle all the actual dealings from messages to actual context creation for LLM and calling the LLM after RAG and context refinement is complete
* When that backend is complete it returns to this implementation and we can simply output the messages
* Removed generateEmbeddings as abstract method as not all potential implementations want to use it