### PR TITLE
[databricks-139] AWS DynamoDb implementasjon for chat history

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -35,7 +35,9 @@
 ### Build
 
 [![TypeScript][typescript]][typescript-url]
+[![Serverless][serverless]][serverless-url]
 [![ExpressJS][expressjs]][expressjs-url]
+[![DynamoDb][dynamodb]][dynamodb-url]
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -45,65 +47,23 @@
 
 ### Database
 
-A database and tables are used to handle the chat history in regard to KnowitGPT.
-At the moment (13.12.2024) there isn't a setup/connection to a database in the cloud, so to properly work with the
-functionality for KnowitGPT, you have to set it up locally.
-There is only the possibility to connect to a PostgresSQL database, since it is the only one with a client implemented.
+A dynamoatabase are used to handle the chat history in regard to KnowitGPT.
+At this moment (13.01.2025) there is only an instance of the database in the development environment.
+The development database is created in the AWS account `knowit-dataplattform-dev`.
 
 #### Setup
-
-There are multiple ways to create a PostgresSQL locally, but personally I used a [Docker](https://www.docker.com/) to
-pull and run a Postgres database and [PgAdmin](https://www.pgadmin.org/) to work with the database with a UI.
-
-I used the following command to run the postgres container names dev-folk-postgres with my own defined password:
-
-```bash
-docker run --name dev-folk-postgres -e POSTGRES_PASSWORD=***** -p 5433:5432 -d postgres
-```
-
-Then I created a database using PgAdmin, but can also be done in the terminal.
-You're now able to connect to the database locally.
-
-#### Connection
 
 In `apps/sever/.env`you'll have to add these variables:
 
 ```
-# PostgresSQL Credentials
-POSTGRES_HOST="localhost"
-POSTGRES_PORT="5432"
-POSTGRES_DATABASE_NAME="_____"
-POSTGRES_PASSWORD="_____"
+# DynamoDb Credentials
+DYNAMODB_TABLE_NAME="dev_knowitgpt_chathistory"
+DYNAMODB_AWS_ACCESS_KEY_ID="_____"
+DYNAMODB_AWS_SECRET_ACCESS_KEY="_____"
+DYNAMODB_AWS_SESSION_TOKEN="_____"
 ```
 
-When using a Docker container, I had to switch to port 5433 for it to work.
-
-#### Working on the database
-
-You'll have to create two tables in you newly created database; `chat` and `chat_message`.
-The columns should be as found for the corresponding classes in the file `apps/server/repository/chat-repository.ts`.
-
-It is possible to set up the tables using an endpoint. If the connection to the database is up, you can use the endpoint
-`/api/v2/database/setup`
-
-Example tables for PostgresSQL
-
-**chat** with columns:
-
-- id: uuid [PKey]
-- user_id: varchar (255)
-- created: timestamp
-- last_updated: timestamp
-- title: varchar (255)
-
-**chat_message** with columns:
-
-- id: uuid [PKey]
-- chat_id: uuid [FKey]
-- user_id: varchar (255)
-- message: text
-- role: varchar (255)
-- created: timestamp
+Use the access keys for `knowit-dataplattform-dev` to work with the database locally.
 
 ### Testing
 
@@ -141,7 +101,11 @@ AZURE_OPENAI_API_KEY=<Azure OpenAI API KEY>
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->
 
+[dynamodb]: https://img.shields.io/badge/DynamoDb-4053D6?style=for-the-badge&logo=amazondynamodb
+[dynamodb-url]: https://aws.amazon.com/dynamodb/
 [expressjs]: https://img.shields.io/badge/Express-000000?style=for-the-badge&logo=express
 [expressjs-url]: https://expressjs.com/
+[serverless]: https://img.shields.io/badge/Serverless-FD5750?style=for-the-badge&logo=serverless&logoColor=white
+[serverless-url]: https://www.serverless.com/
 [typescript]: https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white
 [typescript-url]: https://www.typescriptlang.org/

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -47,9 +47,10 @@
 
 ### Database
 
-A dynamoatabase are used to handle the chat history in regard to KnowitGPT.
+A DynamoDb is used to handle the chat history in regard to KnowitGPT.
 At this moment (13.01.2025) there is only an instance of the database in the development environment.
-The development database is created in the AWS account `knowit-dataplattform-dev`.
+The development database is created in the AWS account `knowit-dataplattform-dev`. When it's time, a production database
+should be created in `knowit-dataplattform-produksjon`.
 
 #### Setup
 

--- a/apps/server/implementations/repositories/dynamodb-chat-repository.ts
+++ b/apps/server/implementations/repositories/dynamodb-chat-repository.ts
@@ -1,0 +1,113 @@
+import {
+  Chat,
+  ChatMessage,
+  ChatRole,
+  IChatRepository,
+} from '../../repository/chat-repository'
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb'
+import { randomUUID } from 'crypto'
+
+export class DynamoDBChatRepository implements IChatRepository {
+  client: DynamoDBDocumentClient
+
+  constructor() {
+    const dynamoDbClient = new DynamoDBClient({})
+    this.client = DynamoDBDocumentClient.from(dynamoDbClient)
+  }
+
+  async addChat(userId: string): Promise<Chat> {
+    try {
+      const chat: Chat = {
+        id: randomUUID().toString(),
+        userId: userId,
+        created: new Date(),
+        lastUpdated: new Date(),
+        title: '',
+      }
+
+      const command = new UpdateCommand({
+        TableName: 'dev_knowitgpt_chathistory',
+        Key: { userId },
+        UpdateExpression:
+          'SET chats = list_append(if_not_exists(chats, :emptyList), :newChat)',
+        ExpressionAttributeValues: {
+          ':emptyList': [],
+          ':newChat': [chat],
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+
+      await this.client.send(command)
+      return chat
+    } catch (error) {
+      console.error('Failed to add chat for user.', error)
+    }
+  }
+  async addChatMessage(
+    chatId: string,
+    userId: string,
+    message: string,
+    role: ChatRole
+  ): Promise<ChatMessage> {
+    try {
+      const messageObject: ChatMessage = {
+        id: randomUUID().toString(),
+        chatId,
+        userId,
+        message,
+        role,
+        created: new Date(),
+      }
+
+      const getChatsCommand = new GetCommand({
+        TableName: 'dev_knowitgpt_chathistory',
+        Key: { userId },
+        ProjectionExpression: 'chats',
+      })
+
+      const { Item } = await this.client.send(getChatsCommand)
+      const chatIndex = Item?.chats.findIndex(
+        (chat: Chat) => chat.id === chatId
+      )
+      if (chatIndex === -1) throw new Error('Chat not found')
+
+      const updateCommand = new UpdateCommand({
+        TableName: 'dev_knowitgpt_chathistory',
+        Key: { userId },
+        UpdateExpression: `SET chats[${chatIndex}].messages = list_append(chats[${chatIndex}].messages, :newMessage)`,
+        ExpressionAttributeValues: {
+          ':newMessage': [messageObject],
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+
+      await this.client.send(updateCommand)
+      return messageObject
+    } catch (error) {
+      console.error('Failed to add chat message to chat.', error)
+    }
+  }
+  async deleteChat(chatId: string): Promise<boolean> {
+    throw new Error('Method not implemented.')
+  }
+
+  async getChat(chatId: string): Promise<Chat> {
+    throw new Error('Method not implemented.')
+  }
+
+  async getChatsForUser(
+    userId: string,
+    limit?: number,
+    offset?: number
+  ): Promise<Array<Chat>> {
+    throw new Error('Method not implemented.')
+  }
+  async getChatMessagesForChat(chatId: string): Promise<Array<ChatMessage>> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/apps/server/implementations/repositories/postgres-chat-repository.ts
+++ b/apps/server/implementations/repositories/postgres-chat-repository.ts
@@ -19,12 +19,12 @@ export class PostgresChatRepository implements IChatRepository {
     })
   }
 
-  async addChat(userId: string): Promise<Chat> {
+  async addChat(userId: string, title: string): Promise<Chat> {
     await this.client.connect()
     try {
       const addChatQuery = {
-        text: 'INSERT INTO chat (user_id) VALUES ($1) RETURNING *',
-        values: [userId],
+        text: 'INSERT INTO chat (user_id, title) VALUES ($1, $2) RETURNING *',
+        values: [userId, title],
       }
       const result = await this.client.query(addChatQuery)
       return result.rows[0]
@@ -52,7 +52,7 @@ export class PostgresChatRepository implements IChatRepository {
     }
   }
 
-  async deleteChat(chatId: string): Promise<boolean> {
+  async deleteChat(userId: string, chatId: string): Promise<boolean> {
     await this.client.connect()
     try {
       const deleteChatQuery = {
@@ -66,7 +66,7 @@ export class PostgresChatRepository implements IChatRepository {
     }
   }
 
-  async getChat(chatId: string): Promise<Chat> {
+  async getChat(userId: string, chatId: string): Promise<Chat> {
     await this.client.connect()
     try {
       const getChatQuery = {
@@ -80,7 +80,10 @@ export class PostgresChatRepository implements IChatRepository {
     }
   }
 
-  async getChatMessagesForChat(chatId: string): Promise<ChatMessage[]> {
+  async getChatMessagesForChat(
+    userId: string,
+    chatId: string
+  ): Promise<ChatMessage[]> {
     await this.client.connect()
     try {
       const getChatMessagesForChatQuery = {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,8 +11,10 @@
     "lint:fix": "run -T eslint --fix ."
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.724.0",
     "@aws-sdk/client-s3": "^3.714.0",
     "@aws-sdk/credential-providers": "^3.714.0",
+    "@aws-sdk/lib-dynamodb": "^3.724.0",
     "@aws-sdk/s3-request-presigner": "^3.714.0",
     "@azure/identity": "4.5.0",
     "@azure/openai": "2.0.0",

--- a/apps/server/repository/chat-repository.ts
+++ b/apps/server/repository/chat-repository.ts
@@ -8,22 +8,23 @@ export interface IChatRepository {
    * Creates a chat for a user.
    *
    * @param userId - The identifier of the user that the chat is created for.
+   * @param title - The title given to the chat.
    * @returns The created chat
    */
-  addChat(userId: string): Promise<Chat>
+  addChat(userId: string, title: string): Promise<Chat>
 
   /**
    * Add a chat message for a chat.
    *
-   * @param chatId - The identifier of the chat that the message is a part of.
    * @param userId - The identifier of the user.
+   * @param chatId - The identifier of the chat that the message is a part of.
    * @param message - The text of the chat entry.
    * @param role - The role of the creator of the entry. It is either the user or the assistant.
    * @returns The created chat message
    */
   addChatMessage(
-    chatId: string,
     userId: string,
+    chatId: string,
     message: string,
     role: ChatRole
   ): Promise<ChatMessage>
@@ -31,18 +32,20 @@ export interface IChatRepository {
   /**
    * Delete a chat. Only the user can delete their own chat.
    *
+   * @param userId - The identifier for the user.
    * @param chatId - The identifier for the chat to be deleted.
    * @returns `true` if an entry is deleted, otherwise `false`.
    */
-  deleteChat(chatId: string): Promise<boolean>
+  deleteChat(userId: string, chatId: string): Promise<boolean>
 
   /**
-   * Retrieves the chat for given chat id.
+   * Retrieve a specific chat for a user.
    *
+   * @param userId - The identifier for the user.
    * @param chatId - The identifier for the chat to retrieve
    * @returns Chat with the given identifier.
    */
-  getChat(chatId: string): Promise<Chat>
+  getChat(userId: string, chatId: string): Promise<Chat>
 
   /**
    * Retrieve all chats for a user.
@@ -61,10 +64,14 @@ export interface IChatRepository {
   /**
    * Retrieve all the chat messages for a chat.
    *
+   * @param userId - The identifier for the user.
    * @param chatId - The identifier for the chat to retrieve messages for.
    * @returns A list of all the chat messages for the chat.
    */
-  getChatMessagesForChat(chatId: string): Promise<Array<ChatMessage>>
+  getChatMessagesForChat(
+    userId: string,
+    chatId: string
+  ): Promise<Array<ChatMessage>>
 }
 
 // A chat user has had with the KnowitGPT

--- a/apps/server/repository/chat-repository.ts
+++ b/apps/server/repository/chat-repository.ts
@@ -37,6 +37,14 @@ export interface IChatRepository {
   deleteChat(chatId: string): Promise<boolean>
 
   /**
+   * Retrieves the chat for given chat id.
+   *
+   * @param chatId - The identifier for the chat to retrieve
+   * @returns Chat with the given identifier.
+   */
+  getChat(chatId: string): Promise<Chat>
+
+  /**
    * Retrieve all chats for a user.
    *
    * @param userId - The identifier for the user to retrieve chats for.

--- a/apps/server/routers/databaseRouter.ts
+++ b/apps/server/routers/databaseRouter.ts
@@ -7,12 +7,12 @@ const router: Router = express.Router()
 const db = new DynamoDBChatRepository()
 
 router.delete('/chats', async (req, res) => {
-  const result = await db.deleteChat(req.body.chatId)
+  const result = await db.deleteChat(req.body.userId, req.body.chatId)
   res.send(result)
 })
 
 router.get('/chat', async (req, res) => {
-  const result = await db.getChat(req.body.chatId)
+  const result = await db.getChat(req.body.userId, req.body.chatId)
   res.send(result)
 })
 
@@ -22,12 +22,15 @@ router.get('/chats', async (req, res) => {
 })
 
 router.get('/chatMessages', async (req, res) => {
-  const result = await db.getChatMessagesForChat(req.body.chatId)
+  const result = await db.getChatMessagesForChat(
+    req.body.userId,
+    req.body.chatId
+  )
   res.send(result)
 })
 
 router.post('/chat', async (req, res) => {
-  const result = await db.addChat(req.body.userId)
+  const result = await db.addChat(req.body.userId, req.body.title)
   res.send(result)
 })
 

--- a/apps/server/routers/databaseRouter.ts
+++ b/apps/server/routers/databaseRouter.ts
@@ -1,5 +1,4 @@
 import express, { Router } from 'express'
-import { PostgresChatRepository } from '../implementations/repositories/postgres-chat-repository'
 import { DynamoDBChatRepository } from '../implementations/repositories/dynamodb-chat-repository'
 
 const router: Router = express.Router()
@@ -11,25 +10,23 @@ router.delete('/chats', async (req, res) => {
   res.send(result)
 })
 
-router.get<unknown, unknown, unknown, string>('/chat', async (req, res) => {
-  const result = await db.getChat(req.query['chatId'])
+router.get('/chat', async (req, res) => {
+  const result = await db.getChat(req.body.userId, req.body.chatId)
   res.send(result)
 })
 
-router.get<unknown, unknown, unknown, string>('/chats', async (req, res) => {
-  const result = await db.getChatsForUser(req.query['userId'])
+router.get('/chats', async (req, res) => {
+  const result = await db.getChatsForUser(req.body.userId)
   res.send(result)
 })
 
-router.get<unknown, unknown, unknown, string>(
-  '/chatMessages',
-  async (req, res) => {
-    console.log(req.query['chatId'])
-    const result = await db.getChatMessagesForChat(req.query['chatId'])
-    console.log(result)
-    res.send(result)
-  }
-)
+router.get('/chatMessages', async (req, res) => {
+  const result = await db.getChatMessagesForChat(
+    req.body.userId,
+    req.body.chatId
+  )
+  res.send(result)
+})
 
 router.post('/chat', async (req, res) => {
   const result = await db.addChat(req.body.userId, req.body.title)
@@ -37,7 +34,6 @@ router.post('/chat', async (req, res) => {
 })
 
 router.post('/chatMessages', async (req, res) => {
-  console.log('ny melding')
   const result = await db.addChatMessage(
     req.body.chatId,
     req.body.userId,
@@ -46,12 +42,5 @@ router.post('/chatMessages', async (req, res) => {
   )
   res.send(result)
 })
-
-/*
-router.post('/setup', async (_, res) => {
-  const result = await db.setupPostgres()
-  res.send(result)
-})
- */
 
 export { router as databaseRouter }

--- a/apps/server/routers/databaseRouter.ts
+++ b/apps/server/routers/databaseRouter.ts
@@ -1,9 +1,10 @@
 import express, { Router } from 'express'
 import { PostgresChatRepository } from '../implementations/repositories/postgres-chat-repository'
+import { DynamoDBChatRepository } from '../implementations/repositories/dynamodb-chat-repository'
 
 const router: Router = express.Router()
 
-const db = new PostgresChatRepository()
+const db = new DynamoDBChatRepository()
 
 router.delete('/chats', async (req, res) => {
   const result = await db.deleteChat(req.body.chatId)
@@ -40,9 +41,11 @@ router.post('/chatMessages', async (req, res) => {
   res.send(result)
 })
 
+/*
 router.post('/setup', async (_, res) => {
   const result = await db.setupPostgres()
   res.send(result)
 })
+ */
 
 export { router as databaseRouter }

--- a/yarn.lock
+++ b/yarn.lock
@@ -514,6 +514,59 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/client-dynamodb@npm:^3.724.0":
+  version: 3.724.0
+  resolution: "@aws-sdk/client-dynamodb@npm:3.724.0"
+  dependencies:
+    "@aws-crypto/sha256-browser": 5.2.0
+    "@aws-crypto/sha256-js": 5.2.0
+    "@aws-sdk/client-sso-oidc": 3.723.0
+    "@aws-sdk/client-sts": 3.723.0
+    "@aws-sdk/core": 3.723.0
+    "@aws-sdk/credential-provider-node": 3.723.0
+    "@aws-sdk/middleware-endpoint-discovery": 3.723.0
+    "@aws-sdk/middleware-host-header": 3.723.0
+    "@aws-sdk/middleware-logger": 3.723.0
+    "@aws-sdk/middleware-recursion-detection": 3.723.0
+    "@aws-sdk/middleware-user-agent": 3.723.0
+    "@aws-sdk/region-config-resolver": 3.723.0
+    "@aws-sdk/types": 3.723.0
+    "@aws-sdk/util-endpoints": 3.723.0
+    "@aws-sdk/util-user-agent-browser": 3.723.0
+    "@aws-sdk/util-user-agent-node": 3.723.0
+    "@smithy/config-resolver": ^4.0.0
+    "@smithy/core": ^3.0.0
+    "@smithy/fetch-http-handler": ^5.0.0
+    "@smithy/hash-node": ^4.0.0
+    "@smithy/invalid-dependency": ^4.0.0
+    "@smithy/middleware-content-length": ^4.0.0
+    "@smithy/middleware-endpoint": ^4.0.0
+    "@smithy/middleware-retry": ^4.0.0
+    "@smithy/middleware-serde": ^4.0.0
+    "@smithy/middleware-stack": ^4.0.0
+    "@smithy/node-config-provider": ^4.0.0
+    "@smithy/node-http-handler": ^4.0.0
+    "@smithy/protocol-http": ^5.0.0
+    "@smithy/smithy-client": ^4.0.0
+    "@smithy/types": ^4.0.0
+    "@smithy/url-parser": ^4.0.0
+    "@smithy/util-base64": ^4.0.0
+    "@smithy/util-body-length-browser": ^4.0.0
+    "@smithy/util-body-length-node": ^4.0.0
+    "@smithy/util-defaults-mode-browser": ^4.0.0
+    "@smithy/util-defaults-mode-node": ^4.0.0
+    "@smithy/util-endpoints": ^3.0.0
+    "@smithy/util-middleware": ^4.0.0
+    "@smithy/util-retry": ^4.0.0
+    "@smithy/util-utf8": ^4.0.0
+    "@smithy/util-waiter": ^4.0.0
+    "@types/uuid": ^9.0.1
+    tslib: ^2.6.2
+    uuid: ^9.0.1
+  checksum: a74fc9ec185c2c9835b67ee4f4544ca7ab982811b29d51fd77b38f0d56951302e9db697a66c2e37062a7fd8647bf4f36f6d38a115c27d2e8db49b3d22bbd000b
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/client-eventbridge@npm:^3.588.0":
   version: 3.723.0
   resolution: "@aws-sdk/client-eventbridge@npm:3.723.0"
@@ -1475,6 +1528,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/endpoint-cache@npm:3.723.0":
+  version: 3.723.0
+  resolution: "@aws-sdk/endpoint-cache@npm:3.723.0"
+  dependencies:
+    mnemonist: 0.38.3
+    tslib: ^2.6.2
+  checksum: a62c9fe468424b6f000247d89337598c1472e6b05f77f2eccb9fe254c10f557d1f5674e71e0414533631fa445425934ee11a8775d1fdfbe389c58299041e9078
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/lib-dynamodb@npm:^3.724.0":
+  version: 3.724.0
+  resolution: "@aws-sdk/lib-dynamodb@npm:3.724.0"
+  dependencies:
+    "@aws-sdk/core": 3.723.0
+    "@aws-sdk/util-dynamodb": 3.724.0
+    "@smithy/core": ^3.0.0
+    "@smithy/smithy-client": ^4.0.0
+    "@smithy/types": ^4.0.0
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-dynamodb": ^3.724.0
+  checksum: 6dff215c206871a3bcf92496148e41ad49b74490f425903724f1b168cd4c7ca4477ad7472a20025666efcf6abb26a9a28abcfafc60827f707f2b6021188b39a4
+  languageName: node
+  linkType: hard
+
 "@aws-sdk/middleware-bucket-endpoint@npm:3.723.0":
   version: 3.723.0
   resolution: "@aws-sdk/middleware-bucket-endpoint@npm:3.723.0"
@@ -1487,6 +1566,20 @@ __metadata:
     "@smithy/util-config-provider": ^4.0.0
     tslib: ^2.6.2
   checksum: 26eecef968389fb29366a870b7aa3b171d5a364c745bfea34d44146f00cfc7fec0f1c12dde74dff94859f6378b30a2dec07b3a3ec854546bcea812853096c1b8
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-endpoint-discovery@npm:3.723.0":
+  version: 3.723.0
+  resolution: "@aws-sdk/middleware-endpoint-discovery@npm:3.723.0"
+  dependencies:
+    "@aws-sdk/endpoint-cache": 3.723.0
+    "@aws-sdk/types": 3.723.0
+    "@smithy/node-config-provider": ^4.0.0
+    "@smithy/protocol-http": ^5.0.0
+    "@smithy/types": ^4.0.0
+    tslib: ^2.6.2
+  checksum: cb9eb78b234b2e03ee3f9db8af6fe2b1629d69dcaa075e60ecb6b8c3643c1f68a5d4ab4366c307c977ec3cee529fd45cf7be0bbde281e2c8fd290a829141ede0
   languageName: node
   linkType: hard
 
@@ -1811,6 +1904,17 @@ __metadata:
   dependencies:
     tslib: ^2.6.2
   checksum: 161935d6ef215a629f5f0909c8d04b478381a9f5687e89df82d9cefa20435fe7c182d16abbbce16926f29d0a310c5acbdaf472c452639d155b08f072904a76d3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/util-dynamodb@npm:3.724.0":
+  version: 3.724.0
+  resolution: "@aws-sdk/util-dynamodb@npm:3.724.0"
+  dependencies:
+    tslib: ^2.6.2
+  peerDependencies:
+    "@aws-sdk/client-dynamodb": ^3.724.0
+  checksum: daa5b71a85080cb030983c1f8c810c301d3cd2ba50b2c7066b7df9088478f99a3c178e6dd7f49a6289675be5005808d34bf67c5c4c7a1826bf3bfcfb656e30c5
   languageName: node
   linkType: hard
 
@@ -13536,6 +13640,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mnemonist@npm:0.38.3":
+  version: 0.38.3
+  resolution: "mnemonist@npm:0.38.3"
+  dependencies:
+    obliterator: ^1.6.1
+  checksum: 894237fc6fd71ec0056eb4a20d9b16dbcd3d77620098dcd3888bdfe3d7a6c9b94355f480aba61a277a16e63c0b99c43f517c0bb283033f982e24b9fcae797447
+  languageName: node
+  linkType: hard
+
 "motion-dom@npm:^11.16.0":
   version: 11.16.0
   resolution: "motion-dom@npm:11.16.0"
@@ -13878,6 +13991,13 @@ __metadata:
     define-properties: ^1.2.1
     es-object-atoms: ^1.0.0
   checksum: f9b9a2a125ccf8ded29414d7c056ae0d187b833ee74919821fc60d7e216626db220d9cb3cf33f965c84aaaa96133626ca13b80f3c158b673976dc8cfcfcd26bb
+  languageName: node
+  linkType: hard
+
+"obliterator@npm:^1.6.1":
+  version: 1.6.1
+  resolution: "obliterator@npm:1.6.1"
+  checksum: 12412ce97bc9680a50ec1e865c9f106f924497f0b73c01947031079da7c9a0f5212f3a1aeea3227f7771ed4a273e42b2a2e6ff93578301c8117dbb3135770133
   languageName: node
   linkType: hard
 
@@ -15419,8 +15539,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server@workspace:apps/server"
   dependencies:
+    "@aws-sdk/client-dynamodb": ^3.724.0
     "@aws-sdk/client-s3": ^3.714.0
     "@aws-sdk/credential-providers": ^3.714.0
+    "@aws-sdk/lib-dynamodb": ^3.724.0
     "@aws-sdk/s3-request-presigner": ^3.714.0
     "@azure/identity": 4.5.0
     "@azure/openai": 2.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -15533,8 +15533,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "server@workspace:apps/server"
   dependencies:
+    "@aws-sdk/client-dynamodb": ^3.724.0
     "@aws-sdk/client-s3": ^3.714.0
     "@aws-sdk/credential-providers": ^3.714.0
+    "@aws-sdk/lib-dynamodb": ^3.724.0
     "@aws-sdk/s3-request-presigner": ^3.714.0
     "@azure/identity": 4.5.0
     "@azure/openai": 2.0.0


### PR DESCRIPTION
#### Hva løser oppgaven:
Chat history skal håndteres i DynamoDb satt opp i AWS.
Denne skal interageres via endepunkt. 

#### Hvordan er oppgaven løst:
* I AWS er det laget en DynamoDb for development miljøet. Denne ligger under kontoen `knowit-dataplattform-dev`.
* Oppdatert signaturene for chat-repository interfacet for å kunne effektivt bruke `partition_key` og `sort_key`. Dette gjør at standard SQL-databaser (dersom man skal bruke det) tar inn et ekstra argument enn nødvendig.
* Slettet setup endepunkt for PostgresSQL lokalt.
* Oppdatert README om DynamoDb og fjernet dokumentasjon om PostgresSQL.